### PR TITLE
depject gives: use true instead of "true"

### DIFF
--- a/modules_core/message-confirm.js
+++ b/modules_core/message-confirm.js
@@ -15,8 +15,8 @@ exports.needs = {
 }
 
 exports.gives = {
-  message_confirm: 'true',
-  mcss: 'true'
+  message_confirm: true,
+  mcss: true
 }
 
 exports.create = function (api) {


### PR DESCRIPTION
fixes `depject` error when smoke testing https://github.com/dominictarr/depject/pull/9