### PR TITLE
extract suggest-box into a helper module which builds suggest boxes

### DIFF
--- a/modules_basic/avatar/image.js
+++ b/modules_basic/avatar/image.js
@@ -79,11 +79,6 @@ exports.create = function (api) {
     avatar_image_src: function (author) {
       var src = ready && avatars[author] ? api.blob_url(avatars[author].image) : genSrc(author)
 
-      if(!ready)
-        waiting.push(() => {
-          if(avatars[author]) src = api.blob_url(avatars[author].image)
-        })
-
       return src
 
       function genSrc (id) {

--- a/modules_basic/avatar/image.js
+++ b/modules_basic/avatar/image.js
@@ -77,9 +77,9 @@ exports.create = function (api) {
     },
 
     avatar_image_src: function (author) {
-      var src = ready && avatars[author] ? api.blob_url(avatars[author].image) : genSrc(author)
-
-      return src
+      return ready && avatars[author]
+        ? api.blob_url(avatars[author].image)
+        : genSrc(author)
 
       function genSrc (id) {
         if(cache[id]) return cache[id]

--- a/modules_basic/avatar/image.js
+++ b/modules_basic/avatar/image.js
@@ -12,7 +12,9 @@ exports.needs = {
 }
 
 exports.gives = {
-  connection_status: true, avatar_image: true
+  connection_status: true, 
+  avatar_image_src: true,
+  avatar_image: true
 }
 
 var ready = false
@@ -72,6 +74,24 @@ exports.create = function (api) {
 
         })
       )
+    },
+
+    avatar_image_src: function (author) {
+      var src = ready && avatars[author] ? api.blob_url(avatars[author].image) : genSrc(author)
+
+      if(!ready)
+        waiting.push(() => {
+          if(avatars[author]) src = api.blob_url(avatars[author].image)
+        })
+
+      return src
+
+      function genSrc (id) {
+        if(cache[id]) return cache[id]
+        var { src } = visualize(new Buffer(author.substring(1), 'base64'), 256)
+        cache[id] = src
+        return src
+      }
     },
 
     avatar_image: function (author, classes) {

--- a/modules_basic/compose.js
+++ b/modules_basic/compose.js
@@ -1,12 +1,11 @@
 'use strict'
 const fs = require('fs')
 const h = require('../h')
-const suggest = require('suggest-box')
 const mentions = require('ssb-mentions')
-const cont = require('cont')
 
 exports.needs = {
   suggest_mentions: 'map', //<-- THIS MUST BE REWRITTEN
+  build_suggest_box: 'first',
   publish: 'first',
   message_content: 'first',
   message_confirm: 'first',
@@ -126,6 +125,8 @@ exports.create = function (api) {
       fileInput, publishBtn
     ])
 
+    api.build_suggest_box(textArea, api.suggest_mentions)
+
     var composer = h('Compose', {
       className: opts.shrink === false ? '-expanded' : '-contracted'
     }, [
@@ -133,15 +134,6 @@ exports.create = function (api) {
       actions
     ])
 
-    suggest(textArea, (name, cb) => {
-      cont.para(api.suggest_mentions(name))
-        ((err, ary) => {
-          cb(null, ary.reduce((a, b) => {
-            if(!b) return a
-            return a.concat(b)
-          }, []))
-        })
-    }, {})
 
     return composer
   }

--- a/modules_core/index.js
+++ b/modules_core/index.js
@@ -10,6 +10,7 @@ module.exports = {
   'sbot':             require('./sbot'),
   'search-box':       require('./search-box'),
   'style':            require('./style'),
+  'suggest-box':      require('./suggest-box'),
   'suggest-mentions': require('./suggest-mentions')
 }
 

--- a/modules_core/search-box.js
+++ b/modules_core/search-box.js
@@ -12,7 +12,7 @@ exports.create = function (api) {
 
   return function (go) {
 
-    var input = h('input.searchprompt', {
+    var search = h('input.searchprompt', {
       type: 'search',
       placeholder: 'Commands',
       onkeydown: ev => {
@@ -21,31 +21,31 @@ exports.create = function (api) {
             ev.stopPropagation()
             suggestBox.complete()
 
-            if (go(input.value.trim(), !ev.ctrlKey))
-              input.blur()
+            if (go(search.value.trim(), !ev.ctrlKey))
+              search.blur()
             return
           case 27: // escape
             ev.preventDefault()
-            input.blur()
+            search.blur()
             return
         }
       }
     })
 
-    input.activate = (sigil, ev) => {
-      input.focus()
+    search.activate = (sigil, ev) => {
+      search.focus()
       ev.preventDefault()
-      if (input.value[0] === sigil) {
-        input.selectionStart = 1
-        input.selectionEnd = input.value.length
+      if (search.value[0] === sigil) {
+        search.selectionStart = 1
+        search.selectionEnd = search.value.length
       } else {
-        input.value = sigil
+        search.value = sigil
       }
     }
 
-    var suggestBox = api.build_suggest_box(input, api.suggest_search)
+    var suggestBox = api.build_suggest_box(search, api.suggest_search)
 
-    return input
+    return search
   }
 
 }

--- a/modules_core/search-box.js
+++ b/modules_core/search-box.js
@@ -1,11 +1,9 @@
 'use strict'
-var cont = require('cont')
 var h = require('hyperscript')
-var suggest = require('suggest-box')
 
 exports.needs = {
-  sbot_query: 'first', sbot_links2: 'first',
-  suggest_search: 'map' //REWRITE
+  suggest_search: 'map', //REWRITE
+  build_suggest_box: 'first'
 }
 
 exports.gives  = 'search_box'
@@ -14,54 +12,40 @@ exports.create = function (api) {
 
   return function (go) {
 
-    var suggestBox
-    var search = h('input.searchprompt', {
+    var input = h('input.searchprompt', {
       type: 'search',
       placeholder: 'Commands',
-      onkeydown: function (ev) {
+      onkeydown: ev => {
         switch (ev.keyCode) {
           case 13: // enter
-            if (suggestBox && suggestBox.active) {
-              suggestBox.complete()
-              ev.stopPropagation()
-            }
-            if (go(search.value.trim(), !ev.ctrlKey))
-              search.blur()
+            ev.stopPropagation()
+            suggestBox.complete()
+
+            if (go(input.value.trim(), !ev.ctrlKey))
+              input.blur()
             return
           case 27: // escape
             ev.preventDefault()
-            search.blur()
+            input.blur()
             return
         }
       }
     })
 
-    search.activate = function (sigil, ev) {
-      search.focus()
+    input.activate = (sigil, ev) => {
+      input.focus()
       ev.preventDefault()
-      if (search.value[0] === sigil) {
-        search.selectionStart = 1
-        search.selectionEnd = search.value.length
+      if (input.value[0] === sigil) {
+        input.selectionStart = 1
+        input.selectionEnd = input.value.length
       } else {
-        search.value = sigil
+        input.value = sigil
       }
     }
 
-    // delay until the element has a parent
-    setTimeout(function () {
-      suggestBox = suggest(search, function (word, cb) {
-        cont.para(api.suggest_search(word))
-          (function (err, ary) {
-            if(err) return cb(err)
+    var suggestBox = api.build_suggest_box(input, api.suggest_search)
 
-            cb(null, ary.filter(Boolean).reduce(function (a, b) {
-              return a.concat(b)
-            }, []))
-          })
-      }, {})
-    }, 10)
-
-    return search
+    return input
   }
 
 }

--- a/modules_core/suggest-box.css
+++ b/modules_core/suggest-box.css
@@ -1,49 +1,66 @@
 /*
- * NOTE the suggest-box module appends the suggestion div to the end of the body,
- * so wrapping it in a module is impossible
- *
- * Writing mcss for this is hard, so I've just written tight css selectors
+NOTE the suggest-box module appends the suggestion div to the end of the body,
+so wrapping it in a module is impossible.
+
+Writing mcss for this is hard, so I've just written tight css selectors
+
+Schema:
+
+  body div.suggest-box ul {
+    li {
+      img {}
+      strong {}
+      small {}
+    }
+
+    li.selected {
+      img {}
+      strong {}
+      small {}
+    }
+  }
 */
+
 
 body > .suggest-box {
   width: max-content;
   background-color: #fff;
   border: 1px gainsboro solid;
+
   padding: .2rem .5rem;
-
-  font-weight: 300;
 }
-
-/* body > .suggest-box > * { */
-/*   display: block; */
-/* } */
 
 body > .suggest-box > ul {
   list-style-type: none;
-  padding-left: 0;
-  border-radius: 2px;
+  padding: 0;
 }
 
 body > .suggest-box > ul > li {
   display: flex;
   align-items: center;
 
-  padding: .1rem .2rem;
-
   border: 1px #fff solid;
+  padding-right: .2rem;
+  margin-bottom: .2rem;
 }
 
 body > .suggest-box > ul > li.selected {
   background: #eee;
-  border-right: 3px black solid;
   border: 1px gainsboro solid;
+}
+
+body > .suggest-box > ul > li > img {
+  height: 36px;
+  width: 36px;
+  margin: 0;
+  padding: 0;
+  /* TODO make smaller emoji thumbnails */
 }
 
 body > .suggest-box > ul > li > strong {
   flex-grow: 1;
-}
-
-body > .suggest-box > ul > li > img {
+  margin-left: .5rem;
+  font-weight: 300;
 }
 
 body > .suggest-box > ul > li > small {
@@ -53,13 +70,4 @@ body > .suggest-box > ul > li > small {
   float: right;
 }
 
-
-
-
-/* emoji */
-
-body > .suggest-box img {
-  height: 20px;
-  width: 20px;
-}
 

--- a/modules_core/suggest-box.css
+++ b/modules_core/suggest-box.css
@@ -39,21 +39,19 @@ body > .suggest-box > ul > li {
   display: flex;
   align-items: center;
 
-  border: 1px #fff solid;
   padding-right: .2rem;
   margin-bottom: .2rem;
 }
 
 body > .suggest-box > ul > li.selected {
-  background: #eee;
-  border: 1px gainsboro solid;
+  color: #fff;
+  background: #0caaf9;
 }
 
 body > .suggest-box > ul > li > img {
   height: 36px;
   width: 36px;
-  margin: 0;
-  padding: 0;
+  padding: .2rem;
   /* TODO make smaller emoji thumbnails */
 }
 
@@ -66,8 +64,7 @@ body > .suggest-box > ul > li > strong {
 body > .suggest-box > ul > li > small {
   font-family: monospace;
   margin-left: .5rem;
+  padding-right: .2rem;
   font-size: 1rem;
-  float: right;
 }
-
 

--- a/modules_core/suggest-box.css
+++ b/modules_core/suggest-box.css
@@ -28,6 +28,7 @@ body > .suggest-box {
   border: 1px gainsboro solid;
 
   padding: .2rem .5rem;
+  margin-top: .7rem;
 }
 
 body > .suggest-box > ul {

--- a/modules_core/suggest-box.css
+++ b/modules_core/suggest-box.css
@@ -1,0 +1,65 @@
+/*
+ * NOTE the suggest-box module appends the suggestion div to the end of the body,
+ * so wrapping it in a module is impossible
+ *
+ * Writing mcss for this is hard, so I've just written tight css selectors
+*/
+
+body > .suggest-box {
+  width: max-content;
+  background-color: #fff;
+  border: 1px gainsboro solid;
+  padding: .2rem .5rem;
+
+  font-weight: 300;
+}
+
+/* body > .suggest-box > * { */
+/*   display: block; */
+/* } */
+
+body > .suggest-box > ul {
+  list-style-type: none;
+  padding-left: 0;
+  border-radius: 2px;
+}
+
+body > .suggest-box > ul > li {
+  display: flex;
+  align-items: center;
+
+  padding: .1rem .2rem;
+
+  border: 1px #fff solid;
+}
+
+body > .suggest-box > ul > li.selected {
+  background: #eee;
+  border-right: 3px black solid;
+  border: 1px gainsboro solid;
+}
+
+body > .suggest-box > ul > li > strong {
+  flex-grow: 1;
+}
+
+body > .suggest-box > ul > li > img {
+}
+
+body > .suggest-box > ul > li > small {
+  font-family: monospace;
+  margin-left: .5rem;
+  font-size: 1rem;
+  float: right;
+}
+
+
+
+
+/* emoji */
+
+body > .suggest-box img {
+  height: 20px;
+  width: 20px;
+}
+

--- a/modules_core/suggest-box.js
+++ b/modules_core/suggest-box.js
@@ -1,0 +1,39 @@
+const fs = require('fs')
+const h = require('../h')
+const { para } = require('cont')
+const suggest = require('suggest-box')
+
+exports.needs = {}
+
+exports.gives = {
+  build_suggest_box: true,
+  css: true
+}
+
+exports.create = function (api) {
+  return {
+    build_suggest_box,
+    css: () => fs.readFileSync(__filename.replace(/js$/, 'css'), 'utf8') //NOTE css
+  }
+
+  function build_suggest_box (inputNode, asyncSuggester, opts = {}) {
+    // NOTE - suggest expects inputNode to have parentNode available
+    var container = h('SuggestBox', inputNode)
+
+    function suggester (inputText, cb) {
+      para(asyncSuggester(inputText))
+        ((err, ary) => {
+          if(err) return cb(err)
+
+          var suggestions = ary.filter(Boolean).reduce((a, b) => a.concat(b), [])
+          cb(null, suggestions)
+        })
+    }
+
+    var suggestBox = suggest(inputNode, suggester, opts)
+
+    return suggestBox // NOTE suggestBox.el = input
+
+  }
+}
+

--- a/modules_core/suggest-box.js
+++ b/modules_core/suggest-box.js
@@ -17,7 +17,7 @@ exports.create = function (api) {
   }
 
   function build_suggest_box (inputNode, asyncSuggester, opts = {}) {
-    // NOTE - suggest expects inputNode to have parentNode available
+    // NOTE - HACK: suggest expects inputNode to have parentNode available
     var container = h('SuggestBox', inputNode)
 
     function suggester (inputText, cb) {

--- a/modules_core/suggest-box.js
+++ b/modules_core/suggest-box.js
@@ -18,7 +18,7 @@ exports.create = function (api) {
 
   function build_suggest_box (inputNode, asyncSuggester, opts = {}) {
     // NOTE - HACK: suggest expects inputNode to have parentNode available
-    var container = h('SuggestBox', inputNode)
+    var container = h('DummyParent', inputNode)
 
     function suggester (inputText, cb) {
       para(asyncSuggester(inputText))
@@ -30,10 +30,8 @@ exports.create = function (api) {
         })
     }
 
-    var suggestBox = suggest(inputNode, suggester, opts)
-
-    return suggestBox // NOTE suggestBox.el = input
-
+    return suggest(inputNode, suggester, opts)
+    // NOTE if ^ is suggestBox, suggestbox.el = inputNode
   }
 }
 

--- a/modules_core/suggest-box.js
+++ b/modules_core/suggest-box.js
@@ -13,7 +13,7 @@ exports.gives = {
 exports.create = function (api) {
   return {
     build_suggest_box,
-    css: () => fs.readFileSync(__filename.replace(/js$/, 'css'), 'utf8') //NOTE css
+    css: () => fs.readFileSync(__filename.replace(/js$/, 'css'), 'utf8') // NOTE css
   }
 
   function build_suggest_box (inputNode, asyncSuggesters, opts = {}) {
@@ -31,7 +31,7 @@ exports.create = function (api) {
     }
 
     return suggest(inputNode, suggester, opts)
-    // NOTE if ^ is suggestBox, suggestbox.el = inputNode
+    // NOTE this returns a suggestBox and suggestbox.el = inputNode if you need it
   }
 }
 

--- a/modules_core/suggest-box.js
+++ b/modules_core/suggest-box.js
@@ -16,12 +16,12 @@ exports.create = function (api) {
     css: () => fs.readFileSync(__filename.replace(/js$/, 'css'), 'utf8') //NOTE css
   }
 
-  function build_suggest_box (inputNode, asyncSuggester, opts = {}) {
+  function build_suggest_box (inputNode, asyncSuggesters, opts = {}) {
     // NOTE - HACK: suggest expects inputNode to have parentNode available
     var container = h('DummyParent', inputNode)
 
     function suggester (inputText, cb) {
-      para(asyncSuggester(inputText))
+      para(asyncSuggesters(inputText))
         ((err, ary) => {
           if(err) return cb(err)
 

--- a/modules_core/suggest-mentions.js
+++ b/modules_core/suggest-mentions.js
@@ -54,7 +54,7 @@ exports.create = function (api) {
             return {
               title: name,
               subtitle: `(${rank}) ${id.substring(0,10)}`,
-              value: '['+name+']('+id+')',
+              value: id,
               rank,
               image: api.avatar_image_src(id),
               showBoth: true
@@ -70,7 +70,7 @@ exports.create = function (api) {
             return {
               title: name,
               subtitle: `(${rank}) ${id.substring(0,10)}`,
-              value: '['+name+']('+id+')',
+              value: id,
               rank
             }
           }))

--- a/modules_core/suggest-mentions.js
+++ b/modules_core/suggest-mentions.js
@@ -4,7 +4,7 @@ exports.needs = {
   blob_url: 'first',
   signified: 'first',
   builtin_tabs: 'map',
-  avatar_image: 'first'
+  avatar_image_src: 'first'
 }
 
 exports.gives = {
@@ -32,11 +32,11 @@ exports.create = function (api) {
           const { name, rank, id } = e
           return {
             title: name,
-            // subtitle: `${id.substring(0,10)} (${rank})`,
             subtitle: `(${rank}) ${id.substring(0,10)}`,
             value: '['+name+']('+id+')',
             rank,
-            // image: avatar_image(e.id)    //TODO: avatar images...
+            image: api.avatar_image_src(id),
+            showBoth: true
           }
         }))
       })
@@ -45,18 +45,36 @@ exports.create = function (api) {
 
   function suggest_search (query) {
     return function (cb) {
-      if(/^[@%]\w/.test(query)) {
-        api.signified(query, function (_, names) {
-          cb(null, names.map(function (e) {
+      if(/^@\w/.test(query)) {
+        api.signified(query, (err, names) => {
+          if(err) return cb(err)
+
+          cb(null, names.map(e => {
+            const { name, rank, id } = e
             return {
-              title: e.name + ':'+e.id.substring(0, 10),
-              value: e.id,
-              subtitle: e.rank,
-              rank: e.rank
+              title: name,
+              subtitle: `(${rank}) ${id.substring(0,10)}`,
+              value: '['+name+']('+id+')',
+              rank,
+              image: api.avatar_image_src(id),
+              showBoth: true
             }
           }))
         })
+      } else if (/^%\w/.test(query)) {
+        api.signified(query, (err, names) => {
+          if(err) return cb(err)
 
+          cb(null, names.map(e => {
+            const { name, rank, id } = e
+            return {
+              title: name,
+              subtitle: `(${rank}) ${id.substring(0,10)}`,
+              value: '['+name+']('+id+')',
+              rank
+            }
+          }))
+        })
       } else if(/^\//.test(query)) {
         var tabs = [].concat.apply([], api.builtin_tabs())
         cb(null, tabs.filter(function (name) {

--- a/modules_core/suggest-mentions.js
+++ b/modules_core/suggest-mentions.js
@@ -3,7 +3,8 @@ exports.needs = {
   sbot_links2: 'first',
   blob_url: 'first',
   signified: 'first',
-  builtin_tabs: 'map'
+  builtin_tabs: 'map',
+  avatar_image: 'first'
 }
 
 exports.gives = {
@@ -24,14 +25,18 @@ exports.create = function (api) {
     return function (cb) {
       if(!/^[%&@]\w/.test(word)) return cb()
 
-      api.signified(word, function (err, names) {
-        if(err) cb(err)
-        else cb(null, names.map(function (e) {
+      api.signified(word, (err, names) => {
+        if(err) return cb(err)
+
+        cb(null, names.map(e => {
+          const { name, rank, id } = e
           return {
-            title: e.name + ': ' + e.id.substring(0,10)+' ('+e.rank+')',
-            value: '['+e.name+']('+e.id+')',
-            rank: e.rank,
-            //TODO: avatar images...
+            title: name,
+            // subtitle: `${id.substring(0,10)} (${rank})`,
+            subtitle: `(${rank}) ${id.substring(0,10)}`,
+            value: '['+name+']('+id+')',
+            rank,
+            // image: avatar_image(e.id)    //TODO: avatar images...
           }
         }))
       })

--- a/modules_core/tabs.js
+++ b/modules_core/tabs.js
@@ -57,7 +57,7 @@ exports.create = function (api) {
     //reposition hypertabs menu to inside a container...
     tabs.insertBefore(h('div.header.row',
         h('div.header__tabs.row', tabs.firstChild), //tabs
-        h('div.header__search.row.end', h('div', search), api.menu())
+        h('div.header__search.row.end', [search, api.menu()])
     ), tabs.firstChild)
   //  tabs.insertBefore(search, tabs.firstChild.nextSibling)
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "ssb-git": "^0.4.1",
     "ssb-keys": "^6.1.0",
     "ssb-links": "^2.0.0",
-    "ssb-markdown": "^3.1.1",
+    "ssb-markdown": "^3.2.1",
     "ssb-mentions": "^0.1.0",
     "ssb-query": "^0.1.1",
     "ssb-ref": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "micro-css": "^0.6.2",
     "mime-types": "^2.1.11",
     "moment": "^2.13.0",
+    "on-load": "^3.2.0",
     "open-external": "^0.1.1",
     "peaks.js": "^0.4.7",
     "pull-cat": "^1.1.9",

--- a/style.css
+++ b/style.css
@@ -178,36 +178,6 @@ button:hover {
 }
 
 
-/* -- suggest box */
-
-.suggest-box > * {
-  display: block;
-}
-
-.suggest-box ul {
-  padding: 0;
-  list-style-type: none;
-  padding-left: 0;
-  background: #eee;
-  border: 1px solid #eee;
-  border-radius: 2px;
-}
-
-.suggest-box .selected {
-  background: white;
-}
-
-.suggest-box {
-  width: max-content;
-  background: #white;
-  border-radius: 1em;
-}
-
-/* emoji */
-.suggest-box img {
-  height: 20px;
-  width: 20px;
-}
 
 /* avatar */
 


### PR DESCRIPTION
~~extract suggest logic into `built_suggest_box` and add some sweet styling~~

[EDIT]

**Context** :

We're using a module called `suggest-box`, which is responsible for the text-complete suggestions on a few types of mentions in the compose + search inputs.

This pull request : 
- adds images to @-mention and emoji-mention type suggestions
- takes advantage of suggest-boxes small text feature to space out the @-mention info
- extracts the suggest-box specific styling into a tighter (specificity) and clearer css module
- extracts a generic `suggest_box_builder`