### PR TITLE
bump scuttlebot version

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "pull-reconnect": "^0.0.3",
     "pull-scroll": "^1.0.1",
     "pull-stream": "^3.4.5",
-    "scuttlebot": "^8.7.2",
+    "scuttlebot": "^9.4.3",
     "setimmediate": "^1.0.5",
     "simple-mime": "^0.1.0",
     "split-buffer": "^1.0.0",


### PR DESCRIPTION
I notice patchbay uses a version of scuttlebot that is behind by a major version. Not sure if there's good reason, but here's a conversation starter.

I was wondering about this after looking at some bugs with my profile feed.
**Should my sbot and patchbay be using the same sbot version ?**

my intuition from basic understanding of muxrpc is yes ?