### PR TITLE
separate electron and browser instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,11 @@ sbot server
 # if you are already running patchwork, that also works.
 # (must have at least >= 2.8)
 
-# then in another tab (these must be 3 separate commands)
+# then in another tab (these must be separate commands)
 sbot plugins.install ssb-links
 sbot plugins.install ssb-query
 sbot plugins.install ssb-ws
+sbot plugins.install ssb-fulltext # for faster searches (optional)
 # restart sbot server (go back to previous tab and kill it)
 ```
 now clone and run patchbay.

--- a/README.md
+++ b/README.md
@@ -2,20 +2,16 @@
 
 Prototype of a pluggable patchwork.
 
-`patchbay` is an secure-scuttlebutt client interface
-that is fully compatible with [patchwork](https://github.com/ssbc/patchwork)
+`patchbay` is a secure-scuttlebutt client interface that is fully compatible with [patchwork](https://github.com/ssbc/patchwork).
 
-I started `patchbay` to experiment with a different internal architecture
-based on [depject](https://github.com/dominictarr/depject). The goal was
-to make it easier to develop new features, and enable or disable features.
-This has so far been quite successful!
+I started `patchbay` to experiment with a different internal architecture based on [depject](https://github.com/dominictarr/depject). The goal was to make it easier to develop new features, and enable or disable features. This has so far been quite successful!
 
-This makes in very easy to create say, a renderer for a new message type,
-or switch to a different method for choosing user names.
+This makes in very easy to create say, a renderer for a new message type, or switch to a different method for choosing user names.
 
-## Running
 
-```
+## Setup
+
+```sh
 npm install scuttlebot@latest -g
 # make sure you have secure-scuttlebutt@15.2.0
 npm ls secure-scuttlebutt -g
@@ -30,59 +26,59 @@ sbot plugins.install ssb-ws
 sbot plugins.install ssb-fulltext # for faster searches (optional)
 # restart sbot server (go back to previous tab and kill it)
 ```
-now clone and run patchbay.
-```
+
+now clone patchbay.
+
+```sh
 git clone https://github.com/ssbc/patchbay.git
 cd patchbay
 npm install
 npm run rebuild
+```
+
+
+## Running the desktop app
+
+From inside the patchbay repo folder, 
+
+```sh
 npm run bundle
 npm start
 ```
 
-## Lite
 
-To run a lite client in the browser instead of using electron, use npm
-run lite from the prompt instead of run bundle. After that you need to
-generate a modern invite:
+## Running in the browser
 
-```
+Make sure scuttlebot is allowing private connections. Stop any running sbot server, restart it with the `--allowPrivate` option and create a new modern invite:
+
+```sh
+sbot server --allowPrivate
 sbot invite.create --modern
 ```
 
-Also set up sbot to allow these connections with:
+From inside the patchbay repo folder, run `npm run lite`.
 
-```
-sbot server --allowPrivate
-```
-
-Lastly open build/index.html in a browser and append the invite
+Lastly open `build/index.html` in a browser and append the invite
 created above using: index.html#ws://localhost:8989....
 
-## how to add a feature
 
-To add a new message type, add add a js to `./modules/` that
-exports a function named `message_content` (it should return an html element)
-To add a new tab, export a function named `screen_view` (returns an html element)
+## How to add a feature
 
-To add a new detail, that appears above a message,
-export a function named `message_meta`.
+To add a new message type, add add a js to `./modules/` that exports a function named `message_content` (it should return an HTML element). To add a new tab, export a function named `screen_view` (returns an html element).
 
-see the code for more examples.
+To add a new detail, that appears above a message, export a function named `message_meta`.
 
-## module graph
+See the code for more examples.
 
-patchbay uses [depject](http://github.com/dominictarr/depject) to manage it's modules.
-here is a graph of the current connections between them. (round shows module,
-square shows api, arrow direction points from user to provider)
+
+## Module graph
+
+patchbay uses [depject](http://github.com/dominictarr/depject) to manage it's modules. Here is a graph of the current connections between them (round shows module, square shows api, arrow direction points from user to provider).
 
 [module graph](./graph.svg)
+
 
 ## License
 
 MIT
-
-
-
-
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ now clone patchbay.
 git clone https://github.com/ssbc/patchbay.git
 cd patchbay
 npm install
-npm run rebuild
 ```
 
 
@@ -42,7 +41,7 @@ npm run rebuild
 From inside the patchbay repo folder, 
 
 ```sh
-npm run bundle
+npm run rebuild
 npm start
 ```
 

--- a/manifest.json
+++ b/manifest.json
@@ -104,6 +104,9 @@
     "changes": "source",
     "createWants": "source"
   },
+  "fulltext": {
+    "search": "source"
+  },
   "links2": {
     "read": "source",
     "dump": "source"

--- a/modules_core/sbot.js
+++ b/modules_core/sbot.js
@@ -43,6 +43,7 @@ module.exports = {
     sbot_links: true,
     sbot_links2: true,
     sbot_query: true,
+    sbot_fulltext_search: true,
     sbot_get: true,
     sbot_log: true,
     sbot_user_feed: true,
@@ -140,6 +141,9 @@ module.exports = {
       }),
       sbot_user_feed: rec.source(function (opts) {
         return sbot.createUserStream(opts)
+      }),
+      sbot_fulltext_search: rec.source(function (opts) {
+        return sbot.fulltext.search(opts)
       }),
       sbot_get: rec.async(function (key, cb) {
         if('function' !== typeof cb)

--- a/modules_extra/network.js
+++ b/modules_extra/network.js
@@ -210,7 +210,7 @@ function obs_gossip_peers (api) {
   refresh()
   
   var sortedIds = computed([state], (state) => {
-    Object.keys(state).sort((a, b) => {
+    return Object.keys(state).sort((a, b) => {
       return peerListSort(state[a], state[b])
     })
   })

--- a/modules_extra/network.js
+++ b/modules_extra/network.js
@@ -208,8 +208,14 @@ function obs_gossip_peers (api) {
   })
 
   refresh()
+  
+  var sortedIds = computed([state], (state) => {
+    Object.keys(state).sort((a, b) => {
+      return peerListSort(state[a], state[b])
+    })
+  })
 
-  return dictToCollection.values(state)
+  return mutantMap(sortedIds, state.get)
 
   function refresh () {
     api.sbot_gossip_peers((err, peers) => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "patchbay",
   "description": "a pluggable patchwork",
-  "version": "6.8.0",
+  "version": "6.9.0",
   "homepage": "https://github.com/ssbc/patchbay",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "scripts": {
     "lite": "mkdir -p build && browserify index.js | indexhtmlify --title patchbay > build/index.html",
     "start": "electro index.js",
-    "bundle": "mkdir -p build && browselectrify index.js > build/bundle.js",
     "rebuild": "npm rebuild --runtime=electron --target=$(electron -v) --abi=$(electron --abi) --disturl=https://atom.io/download/atom-shell",
     "graph": "node index.js | dot -Tsvg > graph.svg",
     "test": "browserify modules_*/index.test.js | tape-run"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "patchbay",
   "description": "a pluggable patchwork",
-  "version": "6.9.0",
+  "version": "6.9.1",
   "homepage": "https://github.com/ssbc/patchbay",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is an attempt to make the README more readable. These are some of the things I was trying to do:

* Fix a couple of small typos.
* Apply some light formatting.
* Make the instructions for the electron and lite versions more distinct.

I'm open to any and all suggestions.