### PR TITLE
remove scoping on mutant dependency

### DIFF
--- a/h.js
+++ b/h.js
@@ -1,4 +1,4 @@
-const { h } = require('@mmckegg/mutant')
+const { h } = require('mutant')
 
 module.exports = require('micro-css/h')(h)
 

--- a/modules_basic/about.js
+++ b/modules_basic/about.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const h = require('../h')
-const { when } = require('@mmckegg/mutant')
+const { when } = require('mutant')
 
 exports.needs = {
   blob_url: 'first',

--- a/modules_basic/avatar/edit.js
+++ b/modules_basic/avatar/edit.js
@@ -8,7 +8,7 @@ const h = require('../../h')
 const {
   Value, Array: MutantArray, Dict: MutantObject, Struct,
   map, computed, when, dictToCollection
-} = require('@mmckegg/mutant')
+} = require('mutant')
 const pull = require('pull-stream')
 const getAvatar = require('ssb-avatar')
 const ref = require('ssb-ref')

--- a/modules_basic/avatar/profile.js
+++ b/modules_basic/avatar/profile.js
@@ -5,7 +5,7 @@ const { unique, drain } = pull
 const {
   Array: MutantArray,
   map, computed, when, dictToCollection
-} = require('@mmckegg/mutant')
+} = require('mutant')
 
 
 exports.needs = {

--- a/modules_basic/compose.js
+++ b/modules_basic/compose.js
@@ -1,7 +1,7 @@
 'use strict'
 const fs = require('fs')
 const h = require('../h')
-const { Value, when } = require('@mmckegg/mutant')
+const { Value, when } = require('mutant')
 const mentions = require('ssb-mentions')
 
 exports.needs = {

--- a/modules_basic/message/author.js
+++ b/modules_basic/message/author.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const h = require('../../h')
-const { when }= require('@mmckegg/mutant')
+const { when }= require('mutant')
 
 exports.needs = {
   avatar_link: 'first',

--- a/modules_core/app.js
+++ b/modules_core/app.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const h = require('../h')
-const { Value } = require('@mmckegg/mutant')
+const { Value } = require('mutant')
 const insertCss = require('insert-css')
 
 exports.needs = {

--- a/modules_extra/network.js
+++ b/modules_extra/network.js
@@ -6,7 +6,7 @@ const human = require('human-time')
 const {
   Struct, Value, Dict,
   dictToCollection, map: mutantMap, when, computed
-} = require('@mmckegg/mutant')
+} = require('mutant')
 
 exports.needs = {
   avatar_image_link: 'first',
@@ -214,7 +214,7 @@ function obs_gossip_peers (api) {
   })
 
   refresh()
-  
+
   var sortedIds = computed([state], (state) => {
     return Object.keys(state).sort((a, b) => {
       return peerListSort(state[a], state[b])
@@ -258,4 +258,3 @@ function Peer () {
 
   return peer
 }
-

--- a/modules_extra/search.js
+++ b/modules_extra/search.js
@@ -1,6 +1,6 @@
 const h = require('../h')
 const fs = require('fs')
-const { Struct, Value, when, computed } = require('@mmckegg/mutant')
+const { Struct, Value, when, computed } = require('mutant')
 const u = require('../util')
 const pull = require('pull-stream')
 const Scroller = require('pull-scroll')

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "browserify modules_*/index.test.js | tape-run"
   },
   "dependencies": {
-    "@mmckegg/mutant": "^3.12.0",
+    "mutant": "~3.12.0",
     "brfs": "^1.4.3",
     "cont": "^1.0.3",
     "dataurl-": "^0.1.0",


### PR DESCRIPTION
Managed to scare of the squatter and nabbed [unprefixed `mutant`](https://www.npmjs.com/package/mutant). 

**This PR updates patchbay to use this version instead!**