### PR TITLE
support `patchbay` to be consumed by `patchbay-lite`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,21 @@ npm install
 From inside the patchbay repo folder, 
 
 ```sh
+npm install -g electron electro
 npm run rebuild
 npm start
 ```
 
-
 ## Running in the browser
+
+_this is incomplete_
+
+From inside the patchbay repo folder, 
+
+```
+npm install -g browserify indexhtmlify
+mkdir -p build && browserify main.js | indexhtmlify --title patchbay > build/index.html
+```
 
 Make sure scuttlebot is allowing private connections. Stop any running sbot server, restart it with the `--allowPrivate` option and create a new modern invite:
 
@@ -73,7 +82,6 @@ From inside the patchbay repo folder, run `npm run lite`.
 
 Lastly open `build/index.html` in a browser and append the invite
 created above using: index.html#ws://localhost:8989....
-
 
 ## How to add a feature
 

--- a/index.js
+++ b/index.js
@@ -1,26 +1,7 @@
-const combine = require('depject')
-const entry = require('depject/entry')
-const nest = require('depnest')
 const bulk = require('bulk-require')
 
-// const git = require('patch-git')
-const horcrux = require('ssb-horcrux')
-const patchbay = { pathcbay: bulk(__dirname, [ '!(node_modules|junk)/**/*.js' ]) }
-const patchcore = require('patchcore')
-
-// polyfills
-require('setimmediate')
-
-// from more specialized to more general
-const sockets = combine(
-  // git,
-  horcrux,
-  patchbay,
-  patchcore
-)
-
-const api = entry(sockets, nest('app.html.app', 'first'))
-
-const app = api.app.html.app()
-document.body.appendChild(app)
-
+module.exports = {
+  patchbay: bulk(__dirname, [
+    '!(node_modules|junk)/**/*.js'
+  ])
+}

--- a/main.js
+++ b/main.js
@@ -1,0 +1,25 @@
+const combine = require('depject')
+const entry = require('depject/entry')
+const nest = require('depnest')
+
+// const git = require('patch-git')
+const horcrux = require('ssb-horcrux')
+const patchbay = require('./')
+const patchcore = require('patchcore')
+
+// polyfills
+require('setimmediate')
+
+// from more specialized to more general
+const sockets = combine(
+  // git,
+  horcrux,
+  patchbay,
+  patchcore
+)
+
+const api = entry(sockets, nest('app.html.app', 'first'))
+
+const app = api.app.html.app()
+document.body.appendChild(app)
+

--- a/package.json
+++ b/package.json
@@ -6,7 +6,14 @@
   "scripts": {
     "lint": "standard",
     "rebuild": "npm rebuild --runtime=electron --target=$(electron -v) --abi=$(electron --abi) --disturl=https://atom.io/download/atom-shell",
-    "start": "electro index.js"
+    "start": "electro main.js"
+  },
+  "browserify": {
+    "transform": [
+      "bulkify",
+      "read-directory/transform",
+      "es2040"
+    ]
   },
   "repository": {
     "type": "git",
@@ -20,11 +27,11 @@
   "homepage": "https://github.com/ssbc/picknmix#readme",
   "dependencies": {
     "bulk-require": "^1.0.0",
+    "bulkify": "^1.4.2",
     "dataurl-": "^0.1.0",
     "depject": "^3.2.0",
     "depnest": "^1.0.2",
-    "electro": "^2.0.3",
-    "electron": "^1.4.15",
+    "es2040": "^1.2.5",
     "hypercrop": "^1.1.0",
     "hyperfile": "^2.0.0",
     "hyperlightbox": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "picknmix",
+  "name": "patchbay",
   "version": "7.1.0",
   "description": "patchbay 2, built on patchcore",
   "main": "index.js",


### PR DESCRIPTION
- export depject modules for external consumption
- add browserify transforms when consuming module
- remove `electro` and `electron` dependencies
- fix up some documentation

https://github.com/ssbc/patchbay/pull/100

/cc @ezdiy