### PR TITLE
Fix the size of emojis

### DIFF
--- a/app/styles/css/global.js
+++ b/app/styles/css/global.js
@@ -15,6 +15,11 @@ body {
   color: #222;
 }
 
+.emoji {
+  width: 16px;
+  height: 16px;
+}
+
 h1, h2, h3, h4, h5, h6, p, ul, ol {
   margin-top: .35em;
 }


### PR DESCRIPTION
The emojis are quite big all of the sudden when running with npm start. This makes them the same size as the text. Not sure if the other things was a feature or not, but I like them smaller :)