### PR TITLE
handle privacy in blobs

### DIFF
--- a/app/html/page/private.js
+++ b/app/html/page/private.js
@@ -49,7 +49,7 @@ exports.create = function (api) {
     const id = api.keys.sync.id()
 
     const composer = api.message.html.compose({
-      meta: { type: 'post' },
+      meta: { type: 'post', private: true, recps: [] },
       prepublish: meta => {
         meta.recps = [id, ...(meta.mentions || [])]
           .filter(m => ref.isFeed(typeof m === 'string' ? m : m.link))

--- a/message/html/compose.js
+++ b/message/html/compose.js
@@ -20,7 +20,13 @@ exports.needs = nest({
 exports.create = function (api) {
   return nest({ 'message.html.compose': compose })
 
-  function compose ({ shrink = true, meta, prepublish, placeholder = 'Write a message' }, cb) {
+  function compose (opts = {}, cb) {
+    var {
+      shrink = true,
+      meta,
+      prepublish,
+      placeholder = 'Write a message'
+    } = opts
     var files = []
     var filesById = {}
     var channelInputFocused = Value(false)
@@ -77,9 +83,10 @@ exports.create = function (api) {
       textArea.value = textArea.value.slice(0, pos) + insertLink + textArea.value.slice(pos)
 
       console.log('added:', file)
-    })
+    }, opts)
 
-    fileInput.onclick = () => hasContent.set(true)
+    if(fileInput)
+      fileInput.onclick = () => hasContent.set(true)
 
     var publishBtn = h('button', { 'ev-click': publish }, 'Publish')
 
@@ -101,6 +108,7 @@ exports.create = function (api) {
         cb(null, getChannelSuggestions(inputText.slice(1)))
       }
     }, {cls: 'SuggestBox'})
+
     channelInput.addEventListener('suggestselect', ev => {
       channelInput.value = ev.detail.id  // HACK : this over-rides the markdown value
     })


### PR DESCRIPTION
blobs are currently not encrypted, but since the button is still there, people (reasonably) assume that it _is_ private. At the very least, we should just not show the file attachment on private messages.

I figure that should actually go in the file plugin though. I was disapointed to see that patchbay and patchwork have nearly exactly the same code in messages/html/compose but it's copied into both programs instead of reused.

Shall we shift that into patchcore? @ahdinosaur @mmckegg ?