### PR TITLE
fix infinitely looping public and private feeds since patchcore update

### DIFF
--- a/app/html/page/private.js
+++ b/app/html/page/private.js
@@ -64,13 +64,13 @@ exports.create = function (api) {
       resetFeed({ container, content })
 
       pull(
-        next(api.feed.pull.private, {old: false, limit: 100}),
+        next(api.feed.pull.private, {old: false, limit: 100}, ['value', 'timestamp']),
         filterDownThrough(),
         Scroller(container, content, api.message.html.render, true, false)
       )
 
       pull(
-        next(api.feed.pull.private, {reverse: true, limit: 100, live: false}),
+        next(api.feed.pull.private, {reverse: true, limit: 100, live: false}, ['value', 'timestamp']),
         filterUpThrough(),
         Scroller(container, content, api.message.html.render, false, false)
       )

--- a/app/html/page/public.js
+++ b/app/html/page/public.js
@@ -61,14 +61,14 @@ exports.create = function (api) {
       }
 
       pull(
-        next(api.feed.pull.public, {old: false, limit: 100}),
+        next(api.feed.pull.public, {old: false, limit: 100}, ['value', 'timestamp']),
         filterDownThrough(),
         Scroller(container, content, api.message.html.render, true, false)
         // Scroller(container, content, ren, true, false)
       )
 
       pull(
-        next(api.feed.pull.public, {reverse: true, limit: 100, live: false}),
+        next(api.feed.pull.public, {reverse: true, limit: 100, live: false}, ['value', 'timestamp']),
         filterUpThrough(),
         Scroller(container, content, api.message.html.render, false, false)
         // Scroller(container, content, ren, true, false)


### PR DESCRIPTION
_**Untested**_

The looping feed problem was caused by patchcore changing to use asserted ordering for `feed.pull.public` and `feed.pull.private`. 

`nextStepper` was sending the wrong `lt` value when requesting the next batch.

**This PR manually sets the correct next step key for these feeds.**
 
---

Interesting to note is that `feed.pull.channel` also changed to asserted ordering, but patchbay isn't using `nextStepper` for this, so was unaffected. You could probably remove `nextStepper` from everything. I suspect it was only there to make the lite client work better.