### PR TITLE
bump ssb-mentions for channel hashtags

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "read-directory": "^2.0.0",
     "setimmediate": "^1.0.5",
     "ssb-horcrux": "^0.1.3",
-    "ssb-mentions": "^0.1.1",
+    "ssb-mentions": "~0.4.0",
     "style-resolve": "^1.0.1",
     "suggest-box": "^2.2.3",
     "text-node-searcher": "^1.1.1",


### PR DESCRIPTION
I just noticed that patchbay is not generating _channel mentions_. This means that posts like [this one](https://viewer.scuttlebot.io/%250q9iOAgBixNFjeLO1UZefzCX1Xsv09Pl2C%2Fl2ACjDQQ%3D.sha256) won't show up under the mentioned channels. 

This is because it is using an old version of `ssb-mentions`. PR updates to the latest version.