### PR TITLE
Fix invisible confirm button for changing names

### DIFF
--- a/about/html/edit.mcss
+++ b/about/html/edit.mcss
@@ -175,9 +175,7 @@ AboutEditor {
       }
 
       button.confirm {
-        color: #fff
         $backgroundPrimary
-        border: none
       }
     }
   }


### PR DESCRIPTION
Seems to be white on white. Not sure how it was broken, but this seems to fix it.