### PR TITLE
Use new version of ssb-chess which does not require sqlite3

### DIFF
--- a/background-process.js
+++ b/background-process.js
@@ -20,6 +20,7 @@ var createSbot = require('scuttlebot')
   .use(require('ssb-fulltext'))
   // .use(require('ssb-ebt'))
   .use(require('ssb-ws'))
+  .use(require('ssb-chess-db'));
 
 // pull config options out of depject
 var config = require('./config').create().config.sync.load()
@@ -28,4 +29,3 @@ var sbot = createSbot(config)
 var manifest = sbot.getManifest()
 fs.writeFileSync(Path.join(config.path, 'manifest.json'), JSON.stringify(manifest))
 electron.ipcRenderer.send('server-started')
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patchbay",
-  "version": "7.12.2",
+  "version": "7.12.3",
   "description": "patchbay 2, built on patchcore",
   "main": "main.js",
   "scripts": {
@@ -73,6 +73,7 @@
     "scuttlebot": "^10.4.4",
     "setimmediate": "^1.0.5",
     "ssb-chess": "^1.5.0",
+    "ssb-chess-db": "1.0.0",
     "ssb-horcrux": "^0.1.3",
     "ssb-mentions": "~0.4.0",
     "ssb-mutual": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "require-style": "^1.0.0",
     "scuttlebot": "^10.4.4",
     "setimmediate": "^1.0.5",
-    "ssb-chess": "^1.5.0",
+    "ssb-chess": "^1.7.1",
     "ssb-chess-db": "1.0.0",
     "ssb-horcrux": "^0.1.3",
     "ssb-mentions": "~0.4.0",


### PR DESCRIPTION
This version of ssb-chess does not require sqlite3. Instead, it uses `flumeview-reduce` in the `ssb-chess-db` scuttlebot plugin.

Before this is merged I'd like someone to test / try out the following:
* Send me a game invite and tell me you've done so I can make sure 'received' invitations are still displayed.
* Make sure the 'observe' tab still looks sensible.
* Make sure the 'my moves' and 'games' tabs still look as you expect.
* View a player's profile and make sure the list of finished games look sensible.