### PR TITLE
deps - patchbay-book@1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "patch-inbox": "^1.0.2",
     "patch-settings": "^1.0.1",
     "patch-suggest": "^1.0.1",
-    "patchbay-book": "^1.0.5",
+    "patchbay-book": "^1.0.3",
     "patchbay-gatherings": "^2.0.0",
     "patchcore": "^1.18.0",
     "pull-abortable": "^4.1.1",


### PR DESCRIPTION
patchbay-book@1.0.5 has not been published to npmjs so trying to `npm i` throws an error. 

This PR fixs version number for patchbay-book to current published version on npm