### PR TITLE
Add keyboard tab controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Patchbay is built using [patchcore](https://github.com/ssbc/patchcore) + [depjec
 
 This makes in very easy to create say, a renderer for a new message type, or switch to a different method for choosing user names.
 
-
 ## Setup
 
 Libsodium has some build dependencies. On ubuntu systems the following might help:
@@ -99,6 +98,14 @@ sbot server
 # from the patchbay repo folder
 npm run dev
 ```
+
+## Keyboard shortcuts
+`CmdOrCtrl` is the `command` key on Apple keyboards or the `ctrl` key on PC keyboards.
+
+### Tabs and Window
+- `CmdOrCtrl+Shift+]` and `CmdOrCtrl+Shift+[` will cycle the tabs left and right
+- `CmdOrCtrl+w` will close the current tab
+- `CmdOrCtrl+Shift+w` will close the current window
 
 ## How to add a feature
 

--- a/app/html/app.js
+++ b/app/html/app.js
@@ -30,7 +30,6 @@ exports.create = function (api) {
     api.app.sync.initialise()
 
     window = api.app.sync.window(window)
- 
     const css = values(api.styles.css()).join('\n')
     insertCss(css)
 
@@ -39,6 +38,18 @@ exports.create = function (api) {
     const tabs = api.app.html.tabs(initialTabs)
 
     const App = h('App', tabs)
+
+    electron.ipcRenderer.on('nextTab', () => {
+      tabs.nextTab()
+    })
+
+    electron.ipcRenderer.on('previousTab', () => {
+      tabs.previousTab()
+    })
+
+    electron.ipcRenderer.on('closeTab', () => {
+      tabs.closeCurrentTab()
+    })
 
     // Catch user actions
     api.app.sync.catchKeyboardShortcut(window, { tabs })

--- a/app/html/tabs.js
+++ b/app/html/tabs.js
@@ -43,7 +43,7 @@ exports.create = function (api) {
       })
       history.set(prunedHistory)
     }
-    
+
     const search = api.app.html.searchBar()
     const menu = api.app.html.menu()
 
@@ -52,7 +52,13 @@ exports.create = function (api) {
       onClose,
       append: h('div.navExtra', [ search, menu ])
     })
-    _tabs.currentPage = () => _tabs.get(_tabs.selected[0]).firstChild
+    _tabs.currentPage = () => {
+      const currentPage = _tabs.get(_tabs.selected[0])
+      return currentPage && currentPage.firstChild
+    }
+    _tabs.nextTab = () => _tabs.currentPage() && _tabs.selectRelative(1)
+    _tabs.previousTab = () => _tabs.currentPage() && _tabs.selectRelative(-1)
+    _tabs.closeCurrentTab = () => _tabs.currentPage() && _tabs.remove(_tabs.selected[0])
 
     // # TODO: review - this works but is strange
     initialTabs.forEach(p => api.app.sync.goTo(p))

--- a/index.js
+++ b/index.js
@@ -22,16 +22,36 @@ electron.app.on('ready', () => {
     { type: 'separator' },
     { role: 'togglefullscreen' }
   ]
-  if (process.platform === 'darwin') {
-    var win = menu.find(x => x.label === 'Window')
-    win.submenu = [
-      { role: 'minimize' },
-      { role: 'zoom' },
-      { role: 'close', label: 'Close' },
-      { type: 'separator' },
-      { role: 'front' }
-    ]
-  }
+  var win = menu.find(x => x.label === 'Window')
+  win.submenu = [
+    { role: 'minimize' },
+    { role: 'zoom' },
+    { role: 'close', label: 'Close Window', accelerator: 'CmdOrCtrl+Shift+W' },
+    { type: 'separator' },
+    {
+      label: 'Close Tab',
+      accelerator: 'CmdOrCtrl+W',
+      click() {
+        windows.main.webContents.send('closeTab')
+      }
+    },
+    {
+      label: 'Select Next Tab',
+      accelerator: 'CmdOrCtrl+Shift+]',
+      click() {
+        windows.main.webContents.send('nextTab')
+      }
+    },
+    {
+      label: 'Select Previous Tab',
+      accelerator: 'CmdOrCtrl+Shift+[',
+      click() {
+        windows.main.webContents.send('previousTab')
+      }
+    },
+    { type: 'separator' },
+    { role: 'front' }
+  ]
 
   Menu.setApplicationMenu(Menu.buildFromTemplate(menu))
 


### PR DESCRIPTION
Tab keyboard shortcuts like Chrome or Firefox

I couldn't prove that windows has a different `Window` menu, if I'm wrong I'm happy to put back the conditional.

Chrome and Firefox has their tab controls under `File` but that seems weird here. Also I'd love to bring in a new tab window but that's a completely new view and I have no idea what it might look like. Additionally I'd love to do an undo close tab but I'm not sure how we'd want to keep history.

![tabcontrol](https://user-images.githubusercontent.com/25966/35189251-70c6b58a-fe14-11e7-85ca-84cfb8403baf.gif)
