### PR TITLE
remove PMs + my posts from /notifications

### DIFF
--- a/app/page/notifications.js
+++ b/app/page/notifications.js
@@ -38,18 +38,24 @@ exports.create = function (api) {
 
     const { filterMenu, filterDownThrough, filterUpThrough, resetFeed } = api.app.html.filter(draw)
     const { container, content } = api.app.html.scroller({ prepend: [ filterMenu ] })
+    const removeMyMessages = () => pull.filter(msg => msg.value.author !== id)
+    const removePrivateMessages = () => pull.filter(msg => msg.value.private !== true)
 
     function draw () {
       resetFeed({ container, content })
 
       pull(
         next(api.feed.pull.mentions(id), {old: false, limit: 100}),
+        removeMyMessages(),
+        removePrivateMessages(),
         filterDownThrough(),
         Scroller(container, content, api.message.html.render, true, false)
       )
 
       pull(
         next(api.feed.pull.mentions(id), {reverse: true, limit: 100, live: false}),
+        removeMyMessages(),
+        removePrivateMessages(),
         filterUpThrough(),
         Scroller(container, content, api.message.html.render, false, false)
       )


### PR DESCRIPTION
I got sick of reading redundent messages in `/notifications`

This is a mini PR which filters out : 
- messages I authored
- messages that are private (which are already in `/private` or `/inbox` which I view as their own dedicated notification area)

I'm going to merge this straight off because it feels small, but happy to discuss. I think notifications need a whole feature built around them in the future, so expect this to be scrapped

cc @Happy0 @arj03 ... who else needs to know?