### PR TITLE
#178 - fix white screen on startup (caused by missing default filter)

### DIFF
--- a/app/html/filter.js
+++ b/app/html/filter.js
@@ -31,7 +31,7 @@ exports.create = function (api) {
 
     const { set } = api.settings.sync
 
-    const filterSettings = api.settings.obs.get('filter')
+    const filterSettings = api.settings.obs.get('filter', {exclude: {}})
 
     const channelInput = h('input',
       { value: filterSettings().exclude.channels,


### PR DESCRIPTION
fixes #178 

This would only affect new users, so that's probably why I got it! There was a setting that was being read before it was written to, causing the following error:

```
base.html:19 TypeError: Cannot read property 'exclude' of undefined
    at Object.Filter (/Users/matt/Code/patchbay/app/html/filter.js:37:32)
    at Object.filter (/Users/matt/Code/patchbay/node_modules/depject/apply.js:15:30)
    at Array.publicPage (/Users/matt/Code/patchbay/app/page/public.js:41:88)
    at Array.<anonymous> (/Users/matt/Code/patchbay/node_modules/depject/apply.js:15:30)
    at /Users/matt/Code/patchbay/node_modules/patchcore/router/sync/router.js:29:31
    at Object.nest (/Users/matt/Code/patchbay/node_modules/patchcore/router/sync/router.js:20:12)
    at Object.router (/Users/matt/Code/patchbay/node_modules/depject/apply.js:15:30)
    at Object.goTo (/Users/matt/Code/patchbay/app/sync/goTo.js:35:34)
    at Object.goTo (/Users/matt/Code/patchbay/node_modules/depject/apply.js:15:30)
    at initialTabs.forEach.p (/Users/matt/Code/patchbay/app/html/tabs.js:64:43)
```

This PR fixes it!