### PR TITLE
#159 - fix patchbay reply forking thread

### DIFF
--- a/app/page/thread.js
+++ b/app/page/thread.js
@@ -14,6 +14,7 @@ exports.needs = nest({
   'message.html.render': 'first',
   'message.async.name': 'first',
   'message.sync.unbox': 'first',
+  'message.sync.root':'first',
   'sbot.async.get': 'first',
   'sbot.pull.links': 'first'
 })
@@ -26,7 +27,11 @@ exports.create = function (api) {
 
     const myId = api.keys.sync.id()
     const ImFollowing = api.contact.obs.following(myId)
-    const { messages, isPrivate, rootId, lastId, channel, recps } = api.feed.obs.thread(key)
+    const { messages, isPrivate, lastId, channel, recps } = api.feed.obs.thread(key)
+    const rootId = computed(messages, (messages) => {
+      return api.message.sync.root(messages[0]) || key
+    })
+
     const meta = Struct({
       type: 'post',
       root: rootId,


### PR DESCRIPTION
This PR fixes the dreaded reply forking bug.

Looks like the patchcore `message.obs.thread` module is a bit messed up, so I just did the root resolution manually in patchbay. I believe this is also how it is done in patchwork.

HURRAY! 🎈 🎉 