### PR TITLE
re-add user filter, add root-only filter

### DIFF
--- a/app/html/filter.mcss
+++ b/app/html/filter.mcss
@@ -57,7 +57,30 @@ Filter {
       justify-content: space-between
       align-items: center
 
-      div.channels {
+      div.users {
+        flex-basis: 100%
+        margin-bottom: .5rem
+
+        display: flex
+        align-items: center
+
+        div.FilterToggle {
+          flex-grow: 1
+        }
+        div.user-filter {
+          label {
+            margin-right: .4rem
+          }
+          input {
+            border: 1px gainsboro solid
+            font-size: 1rem
+          }
+        }
+      }
+      
+      div.channels  {
+        display: flex
+         
         label {
           margin-right: .4rem
         }
@@ -68,12 +91,17 @@ Filter {
       }
 
       div.message-types {
+        flex-basis: 100%
+
         margin: .6rem 0
         display: flex
 
         header {
           margin-right: 1rem
         }
+      }
+
+      div.root-messages {
       }
     }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2665886/37551041-102a370a-29fd-11e8-80d8-97437ee08a44.png)


hey @arj03 here's me putting the user filter back in. It doesn't persist like the others.

I've also added a 'root' filter, which was a feature requested by a colleague - basically it lets you just review the heads of the threads to find things again a little more easily