### PR TITLE
Run `npm update` to bump `sodium-native`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5897,16 +5897,21 @@
       }
     },
     "rc": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
-      "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "requires": {
-        "deep-extend": "~0.4.0",
+        "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
         "minimist": "^1.2.0",
         "strip-json-comments": "~2.0.1"
       },
       "dependencies": {
+        "deep-extend": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,18 @@
       "integrity": "sha1-7739PokNsq2dY8dy0WImZf4GV0M="
     },
     "@types/node": {
-      "version": "8.10.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.21.tgz",
-      "integrity": "sha512-87XkD9qDXm8fIax+5y7drx84cXsu34ZZqfB7Cial3Q/2lxSoJ/+DRaWckkCbxP41wFSIrrb939VhzaNxj4eY1w==",
+      "version": "8.10.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.24.tgz",
+      "integrity": "sha512-5YaBKa6oFuWy7ptIFMATyftIcpZTZtvgrzPThEbs+kl4Uu41oUxiRunG0k32QZjD6MXMELls//ry/epNxc11aQ==",
       "dev": true
+    },
+    "abstract-leveldown": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-4.0.3.tgz",
+      "integrity": "sha512-qsIHFQy0u17JqSY+3ZUT+ykqxYY17yOfvAsLkFkw8kSQqi05d1jyj0bCuSX6sjYlXuY9cKpgUt5EudQdP4aXyA==",
+      "requires": {
+        "xtend": "~4.0.0"
+      }
     },
     "acorn": {
       "version": "5.2.1",
@@ -26,7 +34,7 @@
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0"
+        "acorn": "^3.0.4"
       },
       "dependencies": {
         "acorn": {
@@ -43,10 +51,10 @@
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.1.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       },
       "dependencies": {
         "co": {
@@ -64,15 +72,15 @@
       "dev": true
     },
     "aligned-block-file": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/aligned-block-file/-/aligned-block-file-1.1.2.tgz",
-      "integrity": "sha1-SpFo1f7+Xi9SWUncVaSqCZA7MtQ=",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/aligned-block-file/-/aligned-block-file-1.1.3.tgz",
+      "integrity": "sha512-ai/S+nZ9XMjC0ReZfq94OLGCICVBJyhNiKWmF1J+/GVZZaXtYV805plMi9obaWjfNl/QljB+VOsT+wQ7R858xA==",
       "requires": {
-        "hashlru": "2.2.0",
-        "int53": "0.2.4",
-        "mkdirp": "0.5.1",
+        "hashlru": "^2.1.0",
+        "int53": "^0.2.4",
+        "mkdirp": "^0.5.1",
         "obv": "0.0.0",
-        "uint48be": "1.0.2"
+        "uint48be": "^1.0.1"
       },
       "dependencies": {
         "obv": {
@@ -108,8 +116,8 @@
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "requires": {
-        "micromatch": "2.3.11",
-        "normalize-path": "2.1.1"
+        "micromatch": "^2.1.5",
+        "normalize-path": "^2.0.0"
       }
     },
     "append-batch": {
@@ -123,12 +131,12 @@
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
     "are-we-there-yet": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.3"
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       }
     },
     "argparse": {
@@ -137,7 +145,7 @@
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "arr-diff": {
@@ -145,7 +153,7 @@
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "requires": {
-        "arr-flatten": "1.1.0"
+        "arr-flatten": "^1.0.1"
       }
     },
     "arr-flatten": {
@@ -164,7 +172,7 @@
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -183,10 +191,13 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
     "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-      "dev": true
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
     },
     "assert-plus": {
       "version": "1.0.0",
@@ -221,16 +232,16 @@
       "integrity": "sha1-7ySdyGnWwH59/UoiyKGIULs51/E="
     },
     "atomic-file": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/atomic-file/-/atomic-file-1.1.3.tgz",
-      "integrity": "sha512-T0T/st8MAsbBm1PKBMP+PgKPYlPB+EFak0MbFrJZwzQ3QcgU9kq55BbPNgFnJhHi/pmrJvSQaio6KJUUupDuJg=="
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/atomic-file/-/atomic-file-1.1.5.tgz",
+      "integrity": "sha512-TG+5YFiaKQ6CZiSQsosGMJ/IJzwMZ4V/rSdEXlD6+DwKyv8OyeUcprq34kp4yuS6bfQYXhxBC2Vm8PWo+iKBGQ=="
     },
     "attach-ware": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/attach-ware/-/attach-ware-1.1.1.tgz",
       "integrity": "sha1-KPUTk92LuL2q2XI0JRm/CWIaNaM=",
       "requires": {
-        "unherit": "1.1.0"
+        "unherit": "^1.0.0"
       }
     },
     "aws-sign2": {
@@ -240,9 +251,9 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
     "babel-code-frame": {
@@ -250,9 +261,9 @@
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       },
       "dependencies": {
         "esutils": {
@@ -263,29 +274,29 @@
       }
     },
     "babel-core": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-      "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+      "version": "6.26.3",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+      "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-generator": "6.26.0",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "convert-source-map": "1.5.1",
-        "debug": "2.6.9",
-        "json5": "0.5.1",
-        "lodash": "4.17.10",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.8",
-        "slash": "1.0.0",
-        "source-map": "0.5.7"
+        "babel-code-frame": "^6.26.0",
+        "babel-generator": "^6.26.0",
+        "babel-helpers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "convert-source-map": "^1.5.1",
+        "debug": "^2.6.9",
+        "json5": "^0.5.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4",
+        "path-is-absolute": "^1.0.1",
+        "private": "^0.1.8",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.7"
       },
       "dependencies": {
         "json5": {
@@ -301,18 +312,18 @@
       }
     },
     "babel-generator": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
-      "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
+      "version": "6.26.1",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+      "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
       "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.10",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.7",
+        "trim-right": "^1.0.1"
       },
       "dependencies": {
         "source-map": {
@@ -327,10 +338,10 @@
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-get-function-arity": {
@@ -338,8 +349,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-hoist-variables": {
@@ -347,8 +358,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helpers": {
@@ -356,8 +367,8 @@
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-messages": {
@@ -365,7 +376,7 @@
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-check-es2015-constants": {
@@ -373,7 +384,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -381,7 +392,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
@@ -389,11 +400,11 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.10"
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -401,8 +412,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -410,7 +421,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -418,12 +429,12 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-call-delegate": "^6.24.1",
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -431,8 +442,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -440,7 +451,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -448,7 +459,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-preset-es2040": {
@@ -456,15 +467,15 @@
       "resolved": "https://registry.npmjs.org/babel-preset-es2040/-/babel-preset-es2040-1.1.1.tgz",
       "integrity": "sha1-QIzDNyRwggXHgGZ7kw+njfW8j5Q=",
       "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0"
+        "babel-plugin-check-es2015-constants": "^6.8.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.8.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.9.0",
+        "babel-plugin-transform-es2015-computed-properties": "^6.8.0",
+        "babel-plugin-transform-es2015-destructuring": "^6.9.0",
+        "babel-plugin-transform-es2015-parameters": "^6.9.0",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.8.0",
+        "babel-plugin-transform-es2015-spread": "^6.8.0",
+        "babel-plugin-transform-es2015-template-literals": "^6.8.0"
       }
     },
     "babel-register": {
@@ -472,13 +483,13 @@
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "requires": {
-        "babel-core": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.1",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.10",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18"
+        "babel-core": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.15"
       }
     },
     "babel-runtime": {
@@ -486,8 +497,8 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "2.5.1",
-        "regenerator-runtime": "0.11.0"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       }
     },
     "babel-template": {
@@ -495,11 +506,11 @@
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "lodash": "4.17.10"
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-traverse": {
@@ -507,15 +518,15 @@
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.2",
-        "lodash": "4.17.10"
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
       }
     },
     "babel-types": {
@@ -523,10 +534,10 @@
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.10",
-        "to-fast-properties": "1.0.3"
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
       },
       "dependencies": {
         "esutils": {
@@ -542,14 +553,19 @@
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
     },
     "bail": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.2.tgz",
-      "integrity": "sha1-99bBcxYwqfnw1NNe0fli4gdKF2Q="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.3.tgz",
+      "integrity": "sha512-1X8CnjFVQ+a+KW36uBNMTU5s8+v5FzeqrP7hTG5aTb4aPreSbZJlhwPon9VKMuEVgV++JM+SQrALY3kr7eswdg=="
     },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "base64-url": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-2.2.0.tgz",
+      "integrity": "sha512-Y4qHHAE+rWjmAFPQmHPiiD+hWwM/XvuFLlP6kVxlwZJK7rjiE2uIQR9tZ37iEr1E6iCj9799yxMAmiXzITb3lQ=="
     },
     "bash-color": {
       "version": "0.0.4",
@@ -563,7 +579,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "big.js": {
@@ -577,38 +593,50 @@
       "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
     },
     "binary-search": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.2.tgz",
-      "integrity": "sha1-iMm3vStyIdNS2njsiH9a8lSeTeI="
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.4.tgz",
+      "integrity": "sha512-dPxU/vZLnH0tEVjVPgi015oSwqu6oLfCeHywuFRhBE0yM0mYocvleTl8qsdM1YFhRzTRhM1+VzS8XLDVrHPopg=="
+    },
+    "bindings": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
+      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
     },
     "bl": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
-      "integrity": "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "requires": {
-        "readable-stream": "1.0.34"
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
       },
       "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
         },
         "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
         }
       }
     },
@@ -627,7 +655,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -636,9 +664,9 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
       }
     },
     "broadcast-stream": {
@@ -651,15 +679,34 @@
       "resolved": "https://registry.npmjs.org/browser-split/-/browser-split-0.0.0.tgz",
       "integrity": "sha1-QUGcrvdpdVkp3VGJZ9PuwKYmJ3E="
     },
+    "buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "requires": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+    },
     "buffer-equal": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
       "integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs="
     },
+    "buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
+    },
     "buffer-from": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
-      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
     "builtin-modules": {
@@ -673,7 +720,7 @@
       "resolved": "https://registry.npmjs.org/bulk-require/-/bulk-require-1.0.1.tgz",
       "integrity": "sha1-yz0DnmmBOaRE/FdLJh1rOyz0TIk=",
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.1.1"
       }
     },
     "bulkify": {
@@ -681,10 +728,10 @@
       "resolved": "https://registry.npmjs.org/bulkify/-/bulkify-1.4.2.tgz",
       "integrity": "sha1-eEjw86uX8SpBuSO/kOU+Ceqvukw=",
       "requires": {
-        "bulk-require": "1.0.1",
-        "concat-stream": "1.6.0",
-        "static-module": "1.5.0",
-        "through2": "0.4.2"
+        "bulk-require": "^1.0.0",
+        "concat-stream": "^1.4.5",
+        "static-module": "^1.1.2",
+        "through2": "~0.4.1"
       }
     },
     "bytewise": {
@@ -692,8 +739,8 @@
       "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
       "integrity": "sha1-HRPL/3F65xWAlKqIGzXQgbOHJT4=",
       "requires": {
-        "bytewise-core": "1.2.3",
-        "typewise": "1.0.3"
+        "bytewise-core": "^1.2.2",
+        "typewise": "^1.0.3"
       }
     },
     "bytewise-core": {
@@ -701,7 +748,7 @@
       "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
       "integrity": "sha1-P7QQx+kVWOsasiqCg0V3qmvWHUI=",
       "requires": {
-        "typewise-core": "1.2.0"
+        "typewise-core": "^1.2"
       }
     },
     "caller-path": {
@@ -710,7 +757,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "0.2.0"
+        "callsites": "^0.2.0"
       }
     },
     "callsites": {
@@ -730,8 +777,8 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
       }
     },
     "caseless": {
@@ -741,41 +788,41 @@
       "dev": true
     },
     "ccount": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.2.tgz",
-      "integrity": "sha1-U7ai+BW7d7nChx97mnLDol8djok="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.3.tgz",
+      "integrity": "sha512-Jt9tIBkRc9POUof7QA/VwWd+58fKkEEfI+/t1/eOlxKM7ZhrczNzMFefge7Ai+39y1pR/pP6cI19guHy3FSLmw=="
     },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "character-entities": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.1.tgz",
-      "integrity": "sha1-92hxvl72bdt/j440eOzDdMJ9bco="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.2.tgz",
+      "integrity": "sha512-sMoHX6/nBiy3KKfC78dnEalnpn0Az0oSNvqUWYTtYrhRI5iUIYsROU48G+E+kMFQzqXaJ8kHJZ85n7y6/PHgwQ=="
     },
     "character-entities-html4": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.1.tgz",
-      "integrity": "sha1-NZoqSg9+KdPcKsmb2+Ie45Q46lA="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.2.tgz",
+      "integrity": "sha512-sIrXwyna2+5b0eB9W149izTPJk/KkJTg6mEzDGibwBUkyH1SbDa+nf515Ppdi3MaH35lW0JFJDWeq9Luzes1Iw=="
     },
     "character-entities-legacy": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.1.tgz",
-      "integrity": "sha1-9Ad53xoQGHK7UQo9KV4fzPFHIC8="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.2.tgz",
+      "integrity": "sha512-9NB2VbXtXYWdXzqrvAHykE/f0QJxzaKIpZ5QzNZrrgQ7Iyxr2vnfS8fCBNVW9nUEZE0lo57nxKRqnzY/dKrwlA=="
     },
     "character-reference-invalid": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.1.tgz",
-      "integrity": "sha1-lCg191Dk7GGjCOYMLvjMEBEgLvw="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz",
+      "integrity": "sha512-7I/xceXfKyUJmSAn/jw8ve/9DyOP7XxufNYLI9Px7CmsKgEUaZLUTax6nZxGQtaoiZCjpu6cHPj20xC/vqRReQ=="
     },
     "charwise": {
       "version": "3.0.1",
@@ -788,15 +835,15 @@
       "integrity": "sha512-yOL4Jzsf1/KK4dh7JUDVnAVGYw9K3uqh3p0ZTbjPVum6+UBLHg79JvqX2TT50BybKzJ1+HDlwyolir13dgHrpg=="
     },
     "chloride": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/chloride/-/chloride-2.2.8.tgz",
-      "integrity": "sha1-6/mos8qJp0R8NgOW2t+BfIqY1Zk=",
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/chloride/-/chloride-2.2.10.tgz",
+      "integrity": "sha512-CbU1ISGiB2JBV6PDXx7hkl8D94d2TPD1BANUMFbr8rZYKJi8De2d3Hu2XDIOLAhXf+8yhoFOdjtLG6fxz3QByQ==",
       "requires": {
-        "is-electron": "2.1.0",
-        "sodium-browserify": "1.2.1",
-        "sodium-browserify-tweetnacl": "0.2.3",
-        "sodium-chloride": "1.1.0",
-        "sodium-native": "2.0.1"
+        "is-electron": "^2.0.0",
+        "sodium-browserify": "^1.2.4",
+        "sodium-browserify-tweetnacl": "^0.2.2",
+        "sodium-chloride": "^1.1.0",
+        "sodium-native": "^2.1.6"
       }
     },
     "chloride-test": {
@@ -804,7 +851,7 @@
       "resolved": "https://registry.npmjs.org/chloride-test/-/chloride-test-1.2.2.tgz",
       "integrity": "sha1-F4aGqF6SeARREulujHkXk/mhCuo=",
       "requires": {
-        "json-buffer": "2.0.11"
+        "json-buffer": "^2.0.11"
       }
     },
     "chokidar": {
@@ -812,15 +859,15 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "requires": {
-        "anymatch": "1.3.2",
-        "async-each": "1.0.1",
-        "fsevents": "1.2.4",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
+        "anymatch": "^1.3.0",
+        "async-each": "^1.0.0",
+        "fsevents": "^1.0.0",
+        "glob-parent": "^2.0.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^2.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0"
       }
     },
     "chownr": {
@@ -847,7 +894,7 @@
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "requires": {
-        "restore-cursor": "1.0.1"
+        "restore-cursor": "^1.0.1"
       }
     },
     "cli-width": {
@@ -857,17 +904,17 @@
       "dev": true
     },
     "clone": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
-      "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
     },
     "clone-regexp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.0.tgz",
-      "integrity": "sha1-6uCiQT9VwJQvgYwin+/OhF1/Oxw=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.1.tgz",
+      "integrity": "sha512-Fcij9IwRW27XedRIJnSOEupS7RVcXtObJXbcUOX93UCLqqOdRpkvzKywOOSizmEK/Is3S/RHX9dLdfo6R1Q1mw==",
       "requires": {
-        "is-regexp": "1.0.0",
-        "is-supported-regexp-flag": "1.0.0"
+        "is-regexp": "^1.0.0",
+        "is-supported-regexp-flag": "^1.0.0"
       }
     },
     "co": {
@@ -881,9 +928,9 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "collapse-white-space": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.3.tgz",
-      "integrity": "sha1-S5BvZw5aljqHt2sOFolkM0G2Ajw="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.4.tgz",
+      "integrity": "sha512-YfQ1tAUZm561vpYD+5eyWN8+UsceQbSrqqlc/6zDY2gtAE+uZLSdkkovhnGpmCThsvKBFakq4EdY/FF93E8XIw=="
     },
     "color-hash": {
       "version": "1.0.3",
@@ -896,13 +943,13 @@
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "dev": true,
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.1.tgz",
-      "integrity": "sha512-PCNLExLlI5HiPdaJs4pMXwOTHkSCpNQ1QJH9ykZLKtKEyKu3p9HgmH5l97vM8c0IUz6d54l+xEu2GG9yuYrFzA=="
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.0.tgz",
+      "integrity": "sha512-477o1hdVORiFlZxw8wgsXYCef3lh0zl/OV0FTftqiDxJSWw6dPQ2ipS4k20J2qBcsmsmLKSyr2iFrf9e3JGi4w=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -914,9 +961,9 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "typedarray": "0.0.6"
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "console-control-strings": {
@@ -929,9 +976,9 @@
       "resolved": "https://registry.npmjs.org/cont/-/cont-1.0.3.tgz",
       "integrity": "sha1-aHTx6TX8qZ0EjK6qrZoK6wILzOA=",
       "requires": {
-        "continuable": "1.2.0",
-        "continuable-para": "1.2.0",
-        "continuable-series": "1.2.0"
+        "continuable": "~1.2.0",
+        "continuable-para": "~1.2.0",
+        "continuable-series": "~1.2.0"
       }
     },
     "continuable": {
@@ -944,7 +991,7 @@
       "resolved": "https://registry.npmjs.org/continuable-hash/-/continuable-hash-0.1.4.tgz",
       "integrity": "sha1-gcdNQXcdjJJ4Ph4A5fEbNNbfx4w=",
       "requires": {
-        "continuable": "1.1.8"
+        "continuable": "~1.1.6"
       },
       "dependencies": {
         "continuable": {
@@ -959,7 +1006,7 @@
       "resolved": "https://registry.npmjs.org/continuable-list/-/continuable-list-0.1.6.tgz",
       "integrity": "sha1-h88G7FgHFuEN/5X7C4TF8OisrF8=",
       "requires": {
-        "continuable": "1.1.8"
+        "continuable": "~1.1.6"
       },
       "dependencies": {
         "continuable": {
@@ -974,8 +1021,8 @@
       "resolved": "https://registry.npmjs.org/continuable-para/-/continuable-para-1.2.0.tgz",
       "integrity": "sha1-RFUQ9klFndD8NchyAVFGEicxxYM=",
       "requires": {
-        "continuable-hash": "0.1.4",
-        "continuable-list": "0.1.6"
+        "continuable-hash": "~0.1.4",
+        "continuable-list": "~0.1.5"
       }
     },
     "continuable-series": {
@@ -989,9 +1036,9 @@
       "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
     },
     "core-js": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -1003,10 +1050,10 @@
       "resolved": "https://registry.npmjs.org/cross-script/-/cross-script-1.0.5.tgz",
       "integrity": "sha1-p7sleWLZ/5JoFLJDy8Nru7DpFWk=",
       "requires": {
-        "@f/zip-obj": "1.1.1",
-        "cross-spawn": "5.1.0",
-        "es6-template-regex": "1.0.0",
-        "execall": "1.0.0"
+        "@f/zip-obj": "^1.1.1",
+        "cross-spawn": "^5.1.0",
+        "es6-template-regex": "^1.0.0",
+        "execall": "^1.0.0"
       }
     },
     "cross-spawn": {
@@ -1014,9 +1061,9 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "requires": {
-        "lru-cache": "4.1.1",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "css-modules-loader-core": {
@@ -1037,9 +1084,9 @@
       "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
       "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
       "requires": {
-        "cssesc": "0.1.0",
-        "fastparse": "1.1.1",
-        "regexpu-core": "1.0.0"
+        "cssesc": "^0.1.0",
+        "fastparse": "^1.1.1",
+        "regexpu-core": "^1.0.0"
       }
     },
     "css-url-regex": {
@@ -1057,12 +1104,12 @@
       "resolved": "https://registry.npmjs.org/cssify/-/cssify-1.0.3.tgz",
       "integrity": "sha1-fpzfay/GCFlibSk6ao+yKuoaowg=",
       "requires": {
-        "css-modules-loader-core": "1.1.0",
-        "lodash.assign": "3.2.0",
-        "resolve": "1.5.0",
-        "string-hash": "1.1.3",
-        "stringify-object": "2.4.0",
-        "through2": "2.0.3"
+        "css-modules-loader-core": "^1.0.0",
+        "lodash.assign": "^3.2.0",
+        "resolve": "^1.1.6",
+        "string-hash": "^1.1.0",
+        "stringify-object": "^2.3.1",
+        "through2": "^2.0.0"
       },
       "dependencies": {
         "through2": {
@@ -1070,8 +1117,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "requires": {
-            "readable-stream": "2.3.3",
-            "xtend": "4.0.1"
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -1082,7 +1129,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "1.0.2"
+        "array-find-index": "^1.0.1"
       }
     },
     "d": {
@@ -1091,7 +1138,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.37"
+        "es5-ext": "^0.10.9"
       }
     },
     "dashdash": {
@@ -1100,7 +1147,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "dataurl-": {
@@ -1133,7 +1180,7 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "requires": {
-        "mimic-response": "1.0.0"
+        "mimic-response": "^1.0.0"
       }
     },
     "deep-equal": {
@@ -1157,7 +1204,15 @@
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "requires": {
-        "clone": "1.0.3"
+        "clone": "^1.0.2"
+      }
+    },
+    "deferred-leveldown": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-3.0.0.tgz",
+      "integrity": "sha512-ajbXqRPMXRlcdyt0TuWqknOJkp1JgQjGB7xOl2V+ebol7/U11E9h3/nCZAtN1M7djmAJEIhypCUc1tIWxdQAuQ==",
+      "requires": {
+        "abstract-leveldown": "~4.0.0"
       }
     },
     "define-properties": {
@@ -1165,8 +1220,8 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
       }
     },
     "defined": {
@@ -1180,12 +1235,12 @@
       "integrity": "sha1-TUSr4W7zLHebSXK9FBqAMlApoUo=",
       "dev": true,
       "requires": {
-        "find-root": "1.1.0",
-        "glob": "7.1.2",
-        "ignore": "3.3.7",
-        "pkg-config": "1.1.1",
-        "run-parallel": "1.1.6",
-        "uniq": "1.0.1"
+        "find-root": "^1.0.0",
+        "glob": "^7.0.5",
+        "ignore": "^3.0.9",
+        "pkg-config": "^1.1.0",
+        "run-parallel": "^1.1.2",
+        "uniq": "^1.0.1"
       }
     },
     "del": {
@@ -1194,13 +1249,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
       },
       "dependencies": {
         "globby": {
@@ -1209,12 +1264,12 @@
           "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
           "dev": true,
           "requires": {
-            "array-union": "1.0.2",
-            "arrify": "1.0.1",
-            "glob": "7.1.2",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "array-union": "^1.0.1",
+            "arrify": "^1.0.0",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         }
       }
@@ -1235,7 +1290,7 @@
       "resolved": "https://registry.npmjs.org/depject/-/depject-4.1.1.tgz",
       "integrity": "sha1-6/ciCGgsEfx9BRIjxG6223jVYFg=",
       "requires": {
-        "libnested": "1.3.2"
+        "libnested": "^1.1.0"
       }
     },
     "depnest": {
@@ -1243,8 +1298,8 @@
       "resolved": "https://registry.npmjs.org/depnest/-/depnest-1.3.0.tgz",
       "integrity": "sha1-FL2KNh30RdLTT37LNi1sdFcoiVk=",
       "requires": {
-        "es2040": "1.2.6",
-        "libnested": "1.3.2"
+        "es2040": "^1.2.3",
+        "libnested": "^1.2.1"
       }
     },
     "detab": {
@@ -1252,7 +1307,7 @@
       "resolved": "https://registry.npmjs.org/detab/-/detab-1.0.2.tgz",
       "integrity": "sha1-AbwqSr57x8xnwwOYCO265HBJoO4=",
       "requires": {
-        "repeat-string": "1.6.1"
+        "repeat-string": "^1.5.2"
       }
     },
     "detect-indent": {
@@ -1260,7 +1315,7 @@
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "detect-libc": {
@@ -1274,8 +1329,8 @@
       "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2",
-        "isarray": "1.0.0"
+        "esutils": "^2.0.2",
+        "isarray": "^1.0.0"
       },
       "dependencies": {
         "esutils": {
@@ -1291,7 +1346,7 @@
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
       "requires": {
-        "readable-stream": "1.1.14"
+        "readable-stream": "~1.1.9"
       },
       "dependencies": {
         "isarray": {
@@ -1304,10 +1359,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -1322,18 +1377,19 @@
       "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
       "integrity": "sha1-3uUim98KtrogEqOV4bhpq/iBNHM=",
       "requires": {
-        "onetime": "1.1.0",
-        "set-immediate-shim": "1.0.1"
+        "onetime": "^1.0.0",
+        "set-immediate-shim": "^1.0.0"
       }
     },
     "ecc-jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "ed2curve": {
@@ -1341,7 +1397,7 @@
       "resolved": "https://registry.npmjs.org/ed2curve/-/ed2curve-0.1.4.tgz",
       "integrity": "sha1-lKRCSLuH2jXbDv968KpXYWgRf1k=",
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "0.x.x"
       }
     },
     "electro": {
@@ -1350,8 +1406,8 @@
       "integrity": "sha512-FJ24HKE/GGjvD14lBMcMerS3uIGag1SzOLD03L779bAaTi8uzcM8la06yqCO0vHG7gH0hufF9mL0K69+5a625w==",
       "dev": true,
       "requires": {
-        "minimist": "1.2.0",
-        "subarg": "1.0.0"
+        "minimist": "~1.2.0",
+        "subarg": "^1.0.0"
       },
       "dependencies": {
         "minimist": {
@@ -1363,14 +1419,14 @@
       }
     },
     "electron": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-2.0.5.tgz",
-      "integrity": "sha512-NbWsgAvcxxQrDNaLA2L5adZTKWO6mZwC57uSPQiZiFjpO0K6uVNCjFyRbLnhq8AWq2tmcuzs6mFpIzQXmvlnUQ==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-2.0.6.tgz",
+      "integrity": "sha512-1UHBWHF2EMjjVyTvcdcUBmISnoxElY4cUgkFVslw5pM1HxTVzi2vev+8NBohdLLFGbIbPyNua5vcBg+bxo1rqw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.10.21",
-        "electron-download": "3.3.0",
-        "extract-zip": "1.6.7"
+        "@types/node": "^8.0.24",
+        "electron-download": "^3.0.1",
+        "extract-zip": "^1.0.3"
       }
     },
     "electron-default-menu": {
@@ -1384,15 +1440,15 @@
       "integrity": "sha1-LP1U1pZsAZxNSa1l++Zcyc3vaMg=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "fs-extra": "0.30.0",
-        "home-path": "1.0.6",
-        "minimist": "1.2.0",
-        "nugget": "2.0.1",
-        "path-exists": "2.1.0",
-        "rc": "1.2.2",
-        "semver": "5.4.1",
-        "sumchecker": "1.3.1"
+        "debug": "^2.2.0",
+        "fs-extra": "^0.30.0",
+        "home-path": "^1.0.1",
+        "minimist": "^1.2.0",
+        "nugget": "^2.0.0",
+        "path-exists": "^2.1.0",
+        "rc": "^1.1.2",
+        "semver": "^5.3.0",
+        "sumchecker": "^1.2.0"
       },
       "dependencies": {
         "minimist": {
@@ -1408,9 +1464,9 @@
       "resolved": "https://registry.npmjs.org/electron-window-state/-/electron-window-state-4.1.1.tgz",
       "integrity": "sha1-azT9wxs4UU3+yLfI97XUrdtnYy0=",
       "requires": {
-        "deep-equal": "1.0.1",
-        "jsonfile": "2.4.0",
-        "mkdirp": "0.5.1"
+        "deep-equal": "^1.0.1",
+        "jsonfile": "^2.2.3",
+        "mkdirp": "^0.5.1"
       }
     },
     "elegant-spinner": {
@@ -1428,7 +1484,7 @@
       "resolved": "https://registry.npmjs.org/emoji-server/-/emoji-server-1.0.0.tgz",
       "integrity": "sha1-0GPP7prxGMxa7vvC6bPdUIWBXGM=",
       "requires": {
-        "emoji-named-characters": "1.0.2"
+        "emoji-named-characters": "~1.0.2"
       }
     },
     "encoding-down": {
@@ -1436,20 +1492,12 @@
       "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-4.0.1.tgz",
       "integrity": "sha512-AlSE+ugBIpLL0i9if2SlnOZ4oWj/XvBb8tw2Ie/pFB73vdYs5O/6plRyqIgjbZbz8onaL20AAuMP87LWbP56IQ==",
       "requires": {
-        "abstract-leveldown": "4.0.3",
-        "level-codec": "8.0.0",
-        "level-errors": "1.0.5",
-        "xtend": "4.0.1"
+        "abstract-leveldown": "^4.0.0",
+        "level-codec": "^8.0.0",
+        "level-errors": "^1.0.4",
+        "xtend": "^4.0.1"
       },
       "dependencies": {
-        "abstract-leveldown": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-4.0.3.tgz",
-          "integrity": "sha512-qsIHFQy0u17JqSY+3ZUT+ykqxYY17yOfvAsLkFkw8kSQqi05d1jyj0bCuSX6sjYlXuY9cKpgUt5EudQdP4aXyA==",
-          "requires": {
-            "xtend": "4.0.1"
-          }
-        },
         "level-codec": {
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-8.0.0.tgz",
@@ -1458,11 +1506,11 @@
       }
     },
     "end-of-stream": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "epidemic-broadcast-trees": {
@@ -1470,16 +1518,16 @@
       "resolved": "https://registry.npmjs.org/epidemic-broadcast-trees/-/epidemic-broadcast-trees-6.3.3.tgz",
       "integrity": "sha512-yNbiNBGgX69SleCvOeNL9v7DlqtcEeH6FXZOnGCSgsgcJIZQIMwsQ1HB/j7h+yvnYYh/qqX2iFP9fqR0aukuug==",
       "requires": {
-        "inherits": "2.0.3",
-        "push-stream": "10.0.3"
+        "inherits": "^2.0.3",
+        "push-stream": "^10.0.0"
       }
     },
     "errno": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-      "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "requires": {
-        "prr": "0.0.0"
+        "prr": "~1.0.1"
       }
     },
     "error-ex": {
@@ -1488,7 +1536,7 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
@@ -1496,11 +1544,11 @@
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
       "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
       "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.1",
-        "is-callable": "1.1.4",
-        "is-regex": "1.0.4"
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
       }
     },
     "es-to-primitive": {
@@ -1508,9 +1556,9 @@
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "requires": {
-        "is-callable": "1.1.4",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
+        "is-callable": "^1.1.1",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.1"
       }
     },
     "es2040": {
@@ -1518,9 +1566,9 @@
       "resolved": "https://registry.npmjs.org/es2040/-/es2040-1.2.6.tgz",
       "integrity": "sha512-+sAm7CSGH2+0NMZqm63huevZVoyk8OwF8lVIdwPcNtvZxX3YIITGiui8bfLYS8oNcgCgHNYO+QsgMafwo1OWwg==",
       "requires": {
-        "babel-core": "6.26.0",
-        "babel-preset-es2040": "1.1.1",
-        "through2": "2.0.3"
+        "babel-core": "^6.9.1",
+        "babel-preset-es2040": "^1.1.0",
+        "through2": "^2.0.1"
       },
       "dependencies": {
         "through2": {
@@ -1528,8 +1576,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "requires": {
-            "readable-stream": "2.3.3",
-            "xtend": "4.0.1"
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -1540,8 +1588,8 @@
       "integrity": "sha1-DudB0Ui4AGm6J9AgOTdWryV978M=",
       "dev": true,
       "requires": {
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
+        "es6-iterator": "~2.0.1",
+        "es6-symbol": "~3.1.1"
       }
     },
     "es6-iterator": {
@@ -1550,9 +1598,9 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.37",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
       }
     },
     "es6-map": {
@@ -1561,12 +1609,12 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.37",
-        "es6-iterator": "2.0.3",
-        "es6-set": "0.1.5",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-set": "~0.1.5",
+        "es6-symbol": "~3.1.1",
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-promise": {
@@ -1581,11 +1629,11 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.37",
-        "es6-iterator": "2.0.3",
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
         "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-symbol": {
@@ -1594,8 +1642,8 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.37"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "es6-template-regex": {
@@ -1609,10 +1657,10 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.37",
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.14",
+        "es6-iterator": "^2.0.1",
+        "es6-symbol": "^3.1.1"
       }
     },
     "escape-string-regexp": {
@@ -1625,10 +1673,10 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
       "integrity": "sha1-8CQBb1qI4Eb9EgBQVek5gC5sXyM=",
       "requires": {
-        "esprima": "1.1.1",
-        "estraverse": "1.5.1",
-        "esutils": "1.0.0",
-        "source-map": "0.1.43"
+        "esprima": "~1.1.1",
+        "estraverse": "~1.5.0",
+        "esutils": "~1.0.0",
+        "source-map": "~0.1.33"
       }
     },
     "escope": {
@@ -1637,10 +1685,10 @@
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
       "requires": {
-        "es6-map": "0.1.5",
-        "es6-weak-map": "2.0.2",
-        "esrecurse": "4.2.0",
-        "estraverse": "4.2.0"
+        "es6-map": "^0.1.3",
+        "es6-weak-map": "^2.0.1",
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       },
       "dependencies": {
         "estraverse": {
@@ -1657,40 +1705,40 @@
       "integrity": "sha1-yaEOi/bp1lZRIEd4xQM0Hx6sPOc=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "chalk": "1.1.3",
-        "concat-stream": "1.6.0",
-        "debug": "2.6.9",
-        "doctrine": "1.5.0",
-        "escope": "3.6.0",
-        "espree": "3.5.2",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "glob": "7.1.2",
-        "globals": "9.18.0",
-        "ignore": "3.3.7",
-        "imurmurhash": "0.1.4",
-        "inquirer": "0.12.0",
-        "is-my-json-valid": "2.16.1",
-        "is-resolvable": "1.0.0",
-        "js-yaml": "3.10.0",
-        "json-stable-stringify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.10",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "1.2.1",
-        "progress": "1.1.8",
-        "require-uncached": "1.0.3",
-        "shelljs": "0.7.8",
-        "strip-bom": "3.0.0",
-        "strip-json-comments": "1.0.4",
-        "table": "3.8.3",
-        "text-table": "0.2.0",
-        "user-home": "2.0.0"
+        "babel-code-frame": "^6.16.0",
+        "chalk": "^1.1.3",
+        "concat-stream": "^1.4.6",
+        "debug": "^2.1.1",
+        "doctrine": "^1.2.2",
+        "escope": "^3.6.0",
+        "espree": "^3.3.1",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "glob": "^7.0.3",
+        "globals": "^9.2.0",
+        "ignore": "^3.2.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^0.12.0",
+        "is-my-json-valid": "^2.10.0",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.5.1",
+        "json-stable-stringify": "^1.0.0",
+        "levn": "^0.3.0",
+        "lodash": "^4.0.0",
+        "mkdirp": "^0.5.0",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.1",
+        "pluralize": "^1.2.1",
+        "progress": "^1.1.8",
+        "require-uncached": "^1.0.2",
+        "shelljs": "^0.7.5",
+        "strip-bom": "^3.0.0",
+        "strip-json-comments": "~1.0.1",
+        "table": "^3.7.8",
+        "text-table": "~0.2.0",
+        "user-home": "^2.0.0"
       },
       "dependencies": {
         "estraverse": {
@@ -1743,8 +1791,8 @@
       "integrity": "sha1-Gvlq6lRYVoJRV9l8G1DVqPtkpac=",
       "dev": true,
       "requires": {
-        "doctrine": "1.5.0",
-        "jsx-ast-utils": "1.4.1"
+        "doctrine": "^1.2.2",
+        "jsx-ast-utils": "^1.3.3"
       }
     },
     "eslint-plugin-standard": {
@@ -1759,8 +1807,8 @@
       "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.2.1",
-        "acorn-jsx": "3.0.1"
+        "acorn": "^5.2.1",
+        "acorn-jsx": "^3.0.0"
       }
     },
     "esprima": {
@@ -1774,8 +1822,8 @@
       "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0",
-        "object-assign": "4.1.1"
+        "estraverse": "^4.1.0",
+        "object-assign": "^4.0.1"
       },
       "dependencies": {
         "estraverse": {
@@ -1802,8 +1850,8 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.37"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "execall": {
@@ -1811,7 +1859,7 @@
       "resolved": "https://registry.npmjs.org/execall/-/execall-1.0.0.tgz",
       "integrity": "sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=",
       "requires": {
-        "clone-regexp": "1.0.0"
+        "clone-regexp": "^1.0.0"
       }
     },
     "exit-hook": {
@@ -1824,7 +1872,7 @@
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "requires": {
-        "is-posix-bracket": "0.1.1"
+        "is-posix-bracket": "^0.1.0"
       }
     },
     "expand-range": {
@@ -1832,13 +1880,13 @@
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "requires": {
-        "fill-range": "2.2.3"
+        "fill-range": "^2.1.0"
       }
     },
     "expand-template": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.0.tgz",
-      "integrity": "sha512-kkjwkMqj0h4w/sb32ERCDxCQkREMCAgS39DscDnSwDsbxnwwM1BTZySdC3Bn1lhY7vL08n9GoO/fVTynjDgRyQ=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.1.tgz",
+      "integrity": "sha512-cebqLtV8KOZfw0UI8TEFWxtczxxC1jvyUvx6H4fyp1K1FN7A4Q+uggVUlOsI1K8AGU0rwOGqP8nCapdrw8CYQg=="
     },
     "explain-error": {
       "version": "1.0.4",
@@ -1860,7 +1908,7 @@
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "extract-zip": {
@@ -1881,10 +1929,10 @@
           "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "dev": true,
           "requires": {
-            "buffer-from": "1.1.0",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.3",
-            "typedarray": "0.0.6"
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
           }
         }
       }
@@ -1900,10 +1948,10 @@
       "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.1.0.tgz",
       "integrity": "sha1-lrsXdh2rqU9G0AFzizzt86Z/4Gw=",
       "requires": {
-        "acorn": "5.2.1",
-        "foreach": "2.0.5",
+        "acorn": "^5.0.0",
+        "foreach": "^2.0.5",
         "isarray": "0.0.1",
-        "object-keys": "1.0.11"
+        "object-keys": "^1.0.6"
       },
       "dependencies": {
         "isarray": {
@@ -1947,7 +1995,7 @@
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
       "dev": true,
       "requires": {
-        "pend": "1.2.0"
+        "pend": "~1.2.0"
       }
     },
     "figures": {
@@ -1956,8 +2004,8 @@
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5",
-        "object-assign": "4.1.1"
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
       }
     },
     "file-entry-cache": {
@@ -1966,8 +2014,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.3.0",
-        "object-assign": "4.1.1"
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       }
     },
     "filename-regex": {
@@ -1976,15 +2024,15 @@
       "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
     },
     "fill-range": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
       "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^3.0.0",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
       }
     },
     "find-root": {
@@ -1999,8 +2047,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "flat": {
@@ -2008,14 +2056,7 @@
       "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
       "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
       "requires": {
-        "is-buffer": "2.0.3"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
-        }
+        "is-buffer": "~2.0.3"
       }
     },
     "flat-cache": {
@@ -2024,10 +2065,10 @@
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
       }
     },
     "flatpickr": {
@@ -2040,19 +2081,20 @@
       "resolved": "https://registry.npmjs.org/flumecodec/-/flumecodec-0.0.0.tgz",
       "integrity": "sha1-Ns4Gq+Lg4BxE3WnyoWUwWiMgZJs=",
       "requires": {
-        "level-codec": "6.2.0"
+        "level-codec": "^6.2.0"
       }
     },
     "flumedb": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/flumedb/-/flumedb-0.4.2.tgz",
-      "integrity": "sha1-bqeQFvN5kkISa0sOsCnx86HeWoU=",
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/flumedb/-/flumedb-0.4.9.tgz",
+      "integrity": "sha512-z932cCXHteJXKcwoev8/RfJ9tQ10FeRCZ6Jh55UnxN/ayZraYZvNYObl8ujbho7xQZB1CDt2WTHCN5gEYGBqGw==",
       "requires": {
-        "cont": "1.0.3",
-        "explain-error": "1.0.4",
+        "cont": "^1.0.3",
+        "explain-error": "^1.0.3",
         "obv": "0.0.1",
         "pull-cont": "0.0.0",
-        "pull-stream": "3.6.8"
+        "pull-looper": "^1.0.0",
+        "pull-stream": "^3.5.0"
       },
       "dependencies": {
         "pull-cont": {
@@ -2062,15 +2104,57 @@
         }
       }
     },
+    "flumelog-offset": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/flumelog-offset/-/flumelog-offset-3.3.1.tgz",
+      "integrity": "sha512-4yYdr8tTL0qOkKqhxAxvNnIwDBaBcLEsJWbyc2wU4Ycaewts9xxcBaxNbORp2KBbTwFaqZAV13HVpfZcO1X/AA==",
+      "requires": {
+        "aligned-block-file": "^1.1.2",
+        "append-batch": "^0.0.1",
+        "explain-error": "^1.0.3",
+        "hashlru": "^2.2.0",
+        "int53": "^0.2.4",
+        "looper": "^4.0.0",
+        "ltgt": "^2.1.3",
+        "obv": "0.0.1",
+        "pull-cursor": "^3.0.0",
+        "pull-looper": "^1.0.0",
+        "uint48be": "^1.0.1"
+      }
+    },
     "flumeview-hashtable": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/flumeview-hashtable/-/flumeview-hashtable-1.0.4.tgz",
       "integrity": "sha512-4L52hBelX7dYVAQQ9uPjksqxOCxLwI4NsfEG/+sTM423axT2Poq5cnfdvGm3HzmNowzwDIKtdy429r6PbfKEIw==",
       "requires": {
-        "async-single": "1.0.5",
-        "atomic-file": "1.1.3",
+        "async-single": "^1.0.5",
+        "atomic-file": "^1.1.3",
         "obv": "0.0.1",
-        "pull-stream": "3.6.8"
+        "pull-stream": "^3.6.0"
+      }
+    },
+    "flumeview-level": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/flumeview-level/-/flumeview-level-3.0.5.tgz",
+      "integrity": "sha512-LKW+YdJGemOo7TnUwpFHq4cBBiYAIKtWk+G2CK7zrxbCIiAHemBRudohBOUKuSUZZ0CReR5fJ73peBHW02VerA==",
+      "requires": {
+        "charwise": "^3.0.1",
+        "explain-error": "^1.0.4",
+        "level": "^3.0.1",
+        "ltgt": "^2.1.3",
+        "mkdirp": "^0.5.1",
+        "obv": "0.0.0",
+        "pull-level": "^2.0.3",
+        "pull-paramap": "^1.2.1",
+        "pull-stream": "^3.5.0",
+        "pull-write": "^1.1.1"
+      },
+      "dependencies": {
+        "obv": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/obv/-/obv-0.0.0.tgz",
+          "integrity": "sha1-7eq4Ro+R1BkzYu1/kdC5bdOaecE="
+        }
       }
     },
     "flumeview-query": {
@@ -2078,202 +2162,40 @@
       "resolved": "https://registry.npmjs.org/flumeview-query/-/flumeview-query-6.2.0.tgz",
       "integrity": "sha512-tq7rD63gixBDOPegw10khz/d5Bnq9qW9IbURHbWuJkG5CUBm3JP4QQSIF/Phl99jz66MRuXoXjRrXXQLN89iNQ==",
       "requires": {
-        "deep-equal": "1.0.1",
-        "flumeview-level": "3.0.5",
-        "map-filter-reduce": "3.1.0",
+        "deep-equal": "^1.0.1",
+        "flumeview-level": "^3.0.0",
+        "map-filter-reduce": "^3.0.7",
         "pull-flatmap": "0.0.1",
-        "pull-paramap": "1.2.2",
+        "pull-paramap": "^1.1.3",
         "pull-sink-through": "0.0.0",
-        "pull-stream": "3.6.8"
+        "pull-stream": "^3.4.0"
       },
       "dependencies": {
-        "abstract-leveldown": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-4.0.3.tgz",
-          "integrity": "sha512-qsIHFQy0u17JqSY+3ZUT+ykqxYY17yOfvAsLkFkw8kSQqi05d1jyj0bCuSX6sjYlXuY9cKpgUt5EudQdP4aXyA==",
-          "requires": {
-            "xtend": "4.0.1"
-          }
-        },
-        "bindings": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-          "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
-        },
-        "deferred-leveldown": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-3.0.0.tgz",
-          "integrity": "sha512-ajbXqRPMXRlcdyt0TuWqknOJkp1JgQjGB7xOl2V+ebol7/U11E9h3/nCZAtN1M7djmAJEIhypCUc1tIWxdQAuQ==",
-          "requires": {
-            "abstract-leveldown": "4.0.3"
-          }
-        },
-        "flumeview-level": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/flumeview-level/-/flumeview-level-3.0.5.tgz",
-          "integrity": "sha512-LKW+YdJGemOo7TnUwpFHq4cBBiYAIKtWk+G2CK7zrxbCIiAHemBRudohBOUKuSUZZ0CReR5fJ73peBHW02VerA==",
-          "requires": {
-            "charwise": "3.0.1",
-            "explain-error": "1.0.4",
-            "level": "3.0.2",
-            "ltgt": "2.2.0",
-            "mkdirp": "0.5.1",
-            "obv": "0.0.0",
-            "pull-level": "2.0.3",
-            "pull-paramap": "1.2.2",
-            "pull-stream": "3.6.8",
-            "pull-write": "1.1.4"
-          }
-        },
-        "level": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/level/-/level-3.0.2.tgz",
-          "integrity": "sha512-2qYbbiptPsPWGUI+AgB1gTNXqIjPpALRqrQyNx1zWYNZxhhuzEj/IE4Unu9weEBnsUEocfYe56xOGlAceb8/Fg==",
-          "requires": {
-            "level-packager": "2.1.1",
-            "leveldown": "3.0.2",
-            "opencollective-postinstall": "2.0.0"
-          }
-        },
-        "level-errors": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.1.2.tgz",
-          "integrity": "sha512-Sw/IJwWbPKF5Ai4Wz60B52yj0zYeqzObLh8k1Tk88jVmD51cJSKWSYpRyhVIvFzZdvsPqlH5wfhp/yxdsaQH4w==",
-          "requires": {
-            "errno": "0.1.4"
-          }
-        },
-        "level-iterator-stream": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.3.tgz",
-          "integrity": "sha512-I6Heg70nfF+e5Y3/qfthJFexhRw/Gi3bIymCoXAlijZdAcLaPuWSJs3KXyTYf23ID6g0o2QF62Yh+grOXY3Rig==",
-          "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.3",
-            "xtend": "4.0.1"
-          }
-        },
-        "level-packager": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-2.1.1.tgz",
-          "integrity": "sha512-6l3G6dVkmdvHwOJrEA9d9hL6SSFrzwjQoLP8HsvohOgfY/8Z9LyTKNCM5Gc84wtsUWCuIHu6r+S6WrCtTWUJCw==",
-          "requires": {
-            "encoding-down": "4.0.1",
-            "levelup": "2.0.2"
-          }
-        },
-        "leveldown": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-3.0.2.tgz",
-          "integrity": "sha512-+ANRScj1npQQzv6e4DYAKRjVQZZ+ahMoubKrNP68nIq+l9bYgb+WiXF+14oTcQTg2f7qE9WHGW7rBG9nGSsA+A==",
-          "requires": {
-            "abstract-leveldown": "4.0.3",
-            "bindings": "1.3.0",
-            "fast-future": "1.0.2",
-            "nan": "2.10.0",
-            "prebuild-install": "4.0.0"
-          }
-        },
-        "levelup": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/levelup/-/levelup-2.0.2.tgz",
-          "integrity": "sha512-us+nTLUyd/eLnclYYddOCdAVw1hnymGx/9p4Jr5ThohStsjLqMVmbYiz6/SYFZEPXNF+AKQSvh6fA2e2KZpC8w==",
-          "requires": {
-            "deferred-leveldown": "3.0.0",
-            "level-errors": "1.1.2",
-            "level-iterator-stream": "2.0.3",
-            "xtend": "4.0.1"
-          }
-        },
         "map-filter-reduce": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/map-filter-reduce/-/map-filter-reduce-3.1.0.tgz",
           "integrity": "sha512-os2GlG1lEWRSAvAb9iqfapQ0I1GRXSA+alSjQl0DB7XxNyDx2/VOVAEVhK7EMsqwDDCWNTBSstoo1roc7U5H0w==",
           "requires": {
-            "binary-search": "1.3.2",
+            "binary-search": "^1.2.0",
             "pull-sink-through": "0.0.0",
-            "pull-stream": "3.6.8",
-            "typewiselite": "1.0.0"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        },
-        "nan": {
-          "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
-        },
-        "node-abi": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.4.3.tgz",
-          "integrity": "sha512-b656V5C0628gOOA2kwcpNA/bxdlqYF9FvxJ+qqVX0ctdXNVZpS8J6xEUYir3WAKc7U0BH/NRlSpNbGsy+azjeg==",
-          "requires": {
-            "semver": "5.4.1"
-          }
-        },
-        "obv": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/obv/-/obv-0.0.0.tgz",
-          "integrity": "sha1-7eq4Ro+R1BkzYu1/kdC5bdOaecE="
-        },
-        "prebuild-install": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-4.0.0.tgz",
-          "integrity": "sha512-7tayxeYboJX0RbVzdnKyGl2vhQRWr6qfClEXDhOkXjuaOKCw2q8aiuFhONRYVsG/czia7KhpykIlI2S2VaPunA==",
-          "requires": {
-            "detect-libc": "1.0.3",
-            "expand-template": "1.1.0",
-            "github-from-package": "0.0.0",
-            "minimist": "1.2.0",
-            "mkdirp": "0.5.1",
-            "node-abi": "2.4.3",
-            "noop-logger": "0.1.1",
-            "npmlog": "4.1.2",
-            "os-homedir": "1.0.2",
-            "pump": "2.0.1",
-            "rc": "1.2.2",
-            "simple-get": "2.8.1",
-            "tar-fs": "1.16.0",
-            "tunnel-agent": "0.6.0",
-            "which-pm-runs": "1.0.0"
-          }
-        },
-        "pump": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-          "requires": {
-            "end-of-stream": "1.4.0",
-            "once": "1.4.0"
-          }
-        },
-        "simple-get": {
-          "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
-          "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
-          "requires": {
-            "decompress-response": "3.3.0",
-            "once": "1.4.0",
-            "simple-concat": "1.0.0"
+            "pull-stream": "^3.4.3",
+            "typewiselite": "^1.0.0"
           }
         }
       }
     },
     "flumeview-reduce": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/flumeview-reduce/-/flumeview-reduce-1.3.9.tgz",
-      "integrity": "sha1-WGy0rGpevgeMY+GQHksQf315TzA=",
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/flumeview-reduce/-/flumeview-reduce-1.3.13.tgz",
+      "integrity": "sha512-QN/07+ia3uXpfy8/xWjLI2XGIG67Aiwp9VaOTIqYt6NHP6OfdGfl8nGRPkJRHlkfFbzEouRvJcQBFohWEXMdNQ==",
       "requires": {
-        "async-single": "1.0.5",
-        "atomic-file": "1.1.3",
-        "deep-equal": "1.0.1",
+        "async-single": "^1.0.5",
+        "atomic-file": "^1.1.3",
+        "deep-equal": "^1.0.1",
         "flumecodec": "0.0.0",
         "obv": "0.0.0",
-        "pull-notify": "0.1.1",
-        "pull-stream": "3.6.8"
+        "pull-notify": "^0.1.1",
+        "pull-stream": "^3.5.0"
       },
       "dependencies": {
         "obv": {
@@ -2288,179 +2210,10 @@
       "resolved": "https://registry.npmjs.org/flumeview-search/-/flumeview-search-1.0.4.tgz",
       "integrity": "sha512-iHg3sfqiRAaRU1K+Ir1TGWMDLGxO6ztLl2RFKMYJsojruk+RbcIQjktjxJ4Pzi1igrZsNYDFMOQXoLtyuQgakg==",
       "requires": {
-        "flumeview-level": "3.0.5",
-        "pull-paramap": "1.2.2",
-        "pull-pushable": "2.2.0",
-        "pull-stream": "3.6.8"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-4.0.3.tgz",
-          "integrity": "sha512-qsIHFQy0u17JqSY+3ZUT+ykqxYY17yOfvAsLkFkw8kSQqi05d1jyj0bCuSX6sjYlXuY9cKpgUt5EudQdP4aXyA==",
-          "requires": {
-            "xtend": "4.0.1"
-          }
-        },
-        "bindings": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-          "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
-        },
-        "deferred-leveldown": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-3.0.0.tgz",
-          "integrity": "sha512-ajbXqRPMXRlcdyt0TuWqknOJkp1JgQjGB7xOl2V+ebol7/U11E9h3/nCZAtN1M7djmAJEIhypCUc1tIWxdQAuQ==",
-          "requires": {
-            "abstract-leveldown": "4.0.3"
-          }
-        },
-        "flumeview-level": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/flumeview-level/-/flumeview-level-3.0.5.tgz",
-          "integrity": "sha512-LKW+YdJGemOo7TnUwpFHq4cBBiYAIKtWk+G2CK7zrxbCIiAHemBRudohBOUKuSUZZ0CReR5fJ73peBHW02VerA==",
-          "requires": {
-            "charwise": "3.0.1",
-            "explain-error": "1.0.4",
-            "level": "3.0.2",
-            "ltgt": "2.2.0",
-            "mkdirp": "0.5.1",
-            "obv": "0.0.0",
-            "pull-level": "2.0.3",
-            "pull-paramap": "1.2.2",
-            "pull-stream": "3.6.8",
-            "pull-write": "1.1.4"
-          }
-        },
-        "level": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/level/-/level-3.0.2.tgz",
-          "integrity": "sha512-2qYbbiptPsPWGUI+AgB1gTNXqIjPpALRqrQyNx1zWYNZxhhuzEj/IE4Unu9weEBnsUEocfYe56xOGlAceb8/Fg==",
-          "requires": {
-            "level-packager": "2.1.1",
-            "leveldown": "3.0.2",
-            "opencollective-postinstall": "2.0.0"
-          }
-        },
-        "level-errors": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.1.2.tgz",
-          "integrity": "sha512-Sw/IJwWbPKF5Ai4Wz60B52yj0zYeqzObLh8k1Tk88jVmD51cJSKWSYpRyhVIvFzZdvsPqlH5wfhp/yxdsaQH4w==",
-          "requires": {
-            "errno": "0.1.4"
-          }
-        },
-        "level-iterator-stream": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.3.tgz",
-          "integrity": "sha512-I6Heg70nfF+e5Y3/qfthJFexhRw/Gi3bIymCoXAlijZdAcLaPuWSJs3KXyTYf23ID6g0o2QF62Yh+grOXY3Rig==",
-          "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.3",
-            "xtend": "4.0.1"
-          }
-        },
-        "level-packager": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-2.1.1.tgz",
-          "integrity": "sha512-6l3G6dVkmdvHwOJrEA9d9hL6SSFrzwjQoLP8HsvohOgfY/8Z9LyTKNCM5Gc84wtsUWCuIHu6r+S6WrCtTWUJCw==",
-          "requires": {
-            "encoding-down": "4.0.1",
-            "levelup": "2.0.2"
-          }
-        },
-        "leveldown": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-3.0.2.tgz",
-          "integrity": "sha512-+ANRScj1npQQzv6e4DYAKRjVQZZ+ahMoubKrNP68nIq+l9bYgb+WiXF+14oTcQTg2f7qE9WHGW7rBG9nGSsA+A==",
-          "requires": {
-            "abstract-leveldown": "4.0.3",
-            "bindings": "1.3.0",
-            "fast-future": "1.0.2",
-            "nan": "2.10.0",
-            "prebuild-install": "4.0.0"
-          }
-        },
-        "levelup": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/levelup/-/levelup-2.0.2.tgz",
-          "integrity": "sha512-us+nTLUyd/eLnclYYddOCdAVw1hnymGx/9p4Jr5ThohStsjLqMVmbYiz6/SYFZEPXNF+AKQSvh6fA2e2KZpC8w==",
-          "requires": {
-            "deferred-leveldown": "3.0.0",
-            "level-errors": "1.1.2",
-            "level-iterator-stream": "2.0.3",
-            "xtend": "4.0.1"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        },
-        "nan": {
-          "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
-        },
-        "node-abi": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.4.3.tgz",
-          "integrity": "sha512-b656V5C0628gOOA2kwcpNA/bxdlqYF9FvxJ+qqVX0ctdXNVZpS8J6xEUYir3WAKc7U0BH/NRlSpNbGsy+azjeg==",
-          "requires": {
-            "semver": "5.4.1"
-          }
-        },
-        "obv": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/obv/-/obv-0.0.0.tgz",
-          "integrity": "sha1-7eq4Ro+R1BkzYu1/kdC5bdOaecE="
-        },
-        "prebuild-install": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-4.0.0.tgz",
-          "integrity": "sha512-7tayxeYboJX0RbVzdnKyGl2vhQRWr6qfClEXDhOkXjuaOKCw2q8aiuFhONRYVsG/czia7KhpykIlI2S2VaPunA==",
-          "requires": {
-            "detect-libc": "1.0.3",
-            "expand-template": "1.1.0",
-            "github-from-package": "0.0.0",
-            "minimist": "1.2.0",
-            "mkdirp": "0.5.1",
-            "node-abi": "2.4.3",
-            "noop-logger": "0.1.1",
-            "npmlog": "4.1.2",
-            "os-homedir": "1.0.2",
-            "pump": "2.0.1",
-            "rc": "1.2.2",
-            "simple-get": "2.8.1",
-            "tar-fs": "1.16.0",
-            "tunnel-agent": "0.6.0",
-            "which-pm-runs": "1.0.0"
-          }
-        },
-        "pull-pushable": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.2.0.tgz",
-          "integrity": "sha1-Xy867UethpGfAbEqLpnW8b13ZYE="
-        },
-        "pump": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-          "requires": {
-            "end-of-stream": "1.4.0",
-            "once": "1.4.0"
-          }
-        },
-        "simple-get": {
-          "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
-          "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
-          "requires": {
-            "decompress-response": "3.3.0",
-            "once": "1.4.0",
-            "simple-concat": "1.0.0"
-          }
-        }
+        "flumeview-level": "^3.0.4",
+        "pull-paramap": "^1.2.2",
+        "pull-pushable": "^2.2.0",
+        "pull-stream": "^3.0.1"
       }
     },
     "font-awesome": {
@@ -2473,7 +2226,7 @@
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "requires": {
-        "is-callable": "1.1.4"
+        "is-callable": "^1.1.3"
       }
     },
     "for-in": {
@@ -2486,7 +2239,7 @@
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "foreach": {
@@ -2506,9 +2259,9 @@
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "dev": true,
       "requires": {
-        "asynckit": "0.4.0",
+        "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "2.1.19"
+        "mime-types": "^2.1.12"
       }
     },
     "from2": {
@@ -2516,8 +2269,8 @@
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
       }
     },
     "from2-string": {
@@ -2525,8 +2278,13 @@
       "resolved": "https://registry.npmjs.org/from2-string/-/from2-string-1.1.0.tgz",
       "integrity": "sha1-GCgrJ9CKJnyzAwzSuLSw8hKvdSo=",
       "requires": {
-        "from2": "2.3.0"
+        "from2": "^2.0.3"
       }
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs-extra": {
       "version": "0.30.0",
@@ -2534,11 +2292,11 @@
       "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "2.4.0",
-        "klaw": "1.3.1",
-        "path-is-absolute": "1.0.1",
-        "rimraf": "2.6.2"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0",
+        "klaw": "^1.0.0",
+        "path-is-absolute": "^1.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "fs.realpath": {
@@ -2552,8 +2310,8 @@
       "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
       "optional": true,
       "requires": {
-        "nan": "2.10.0",
-        "node-pre-gyp": "0.10.0"
+        "nan": "^2.9.2",
+        "node-pre-gyp": "^0.10.0"
       },
       "dependencies": {
         "abbrev": {
@@ -2575,8 +2333,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.6"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
         },
         "balanced-match": {
@@ -2587,7 +2345,7 @@
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -2641,7 +2399,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "^2.2.1"
           }
         },
         "fs.realpath": {
@@ -2654,14 +2412,14 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "aproba": "1.2.0",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "glob": {
@@ -2669,12 +2427,12 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-unicode": {
@@ -2687,7 +2445,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": "^2.1.0"
           }
         },
         "ignore-walk": {
@@ -2695,7 +2453,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "minimatch": "3.0.4"
+            "minimatch": "^3.0.4"
           }
         },
         "inflight": {
@@ -2703,8 +2461,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -2720,7 +2478,7 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
@@ -2732,7 +2490,7 @@
           "version": "3.0.4",
           "bundled": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -2743,8 +2501,8 @@
           "version": "2.2.4",
           "bundled": true,
           "requires": {
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.0"
           }
         },
         "minizlib": {
@@ -2752,7 +2510,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "^2.2.1"
           }
         },
         "mkdirp": {
@@ -2767,20 +2525,14 @@
           "bundled": true,
           "optional": true
         },
-        "nan": {
-          "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
-          "optional": true
-        },
         "needle": {
           "version": "2.2.0",
           "bundled": true,
           "optional": true,
           "requires": {
-            "debug": "2.6.9",
-            "iconv-lite": "0.4.21",
-            "sax": "1.2.4"
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -2788,16 +2540,16 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "detect-libc": "1.0.3",
-            "mkdirp": "0.5.1",
-            "needle": "2.2.0",
-            "nopt": "4.0.1",
-            "npm-packlist": "1.1.10",
-            "npmlog": "4.1.2",
-            "rc": "1.2.7",
-            "rimraf": "2.6.2",
-            "semver": "5.5.0",
-            "tar": "4.4.1"
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.0",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
           }
         },
         "nopt": {
@@ -2805,8 +2557,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "npm-bundled": {
@@ -2819,8 +2571,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.3"
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
           }
         },
         "npmlog": {
@@ -2828,10 +2580,10 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
@@ -2847,7 +2599,7 @@
           "version": "1.4.0",
           "bundled": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -2865,8 +2617,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
@@ -2884,10 +2636,10 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.5.1",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "^0.5.1",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -2902,13 +2654,13 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "rimraf": {
@@ -2916,7 +2668,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
@@ -2952,9 +2704,9 @@
           "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
@@ -2962,14 +2714,14 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -2982,13 +2734,13 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "chownr": "1.0.1",
-            "fs-minipass": "1.2.5",
-            "minipass": "2.2.4",
-            "minizlib": "1.1.0",
-            "mkdirp": "0.5.1",
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.2.4",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.2"
           }
         },
         "util-deprecate": {
@@ -3001,7 +2753,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2"
           }
         },
         "wrappy": {
@@ -3024,14 +2776,14 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "requires": {
-        "aproba": "1.2.0",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
       }
     },
     "generate-function": {
@@ -3044,7 +2796,7 @@
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "requires": {
-        "is-property": "1.0.2"
+        "is-property": "^1.0.0"
       }
     },
     "get-stdin": {
@@ -3059,7 +2811,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "git-packidx-parser": {
@@ -3067,7 +2819,7 @@
       "resolved": "https://registry.npmjs.org/git-packidx-parser/-/git-packidx-parser-1.0.0.tgz",
       "integrity": "sha1-xX0RRe7BZGWrm/vfV1JisWkWJNY=",
       "requires": {
-        "through": "2.2.7"
+        "through": "~2.2.7"
       }
     },
     "github-from-package": {
@@ -3080,12 +2832,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-base": {
@@ -3093,8 +2845,8 @@
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "glob-parent": {
@@ -3102,7 +2854,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "^2.0.0"
       }
     },
     "globals": {
@@ -3115,12 +2867,12 @@
       "resolved": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
       "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
       "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "6.0.4",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^6.0.1",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       },
       "dependencies": {
         "glob": {
@@ -3128,11 +2880,11 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -3147,7 +2899,7 @@
       "resolved": "https://registry.npmjs.org/graphreduce/-/graphreduce-3.0.4.tgz",
       "integrity": "sha1-v0QtCoeOg5AeXvPmUtI/+1uDHtc=",
       "requires": {
-        "statistics": "3.3.0"
+        "statistics": "^3.3.0"
       }
     },
     "har-schema": {
@@ -3162,16 +2914,16 @@
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
       }
     },
     "has": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.1.1"
       }
     },
     "has-ansi": {
@@ -3179,7 +2931,7 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -3198,9 +2950,9 @@
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
     "hashlru": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.2.0.tgz",
-      "integrity": "sha1-eTpYlD+QKupXgXfXsDNfE/JpS3E="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.2.1.tgz",
+      "integrity": "sha1-EPIJmg18BaQPK+r1wdOc8vfavzY="
     },
     "he": {
       "version": "0.5.0",
@@ -3217,8 +2969,8 @@
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
       }
     },
     "home-path": {
@@ -3253,7 +3005,7 @@
       "resolved": "https://registry.npmjs.org/html-element/-/html-element-1.3.0.tgz",
       "integrity": "sha1-117LXa6HSx3mCgv4eUu9GYTQ8gk=",
       "requires": {
-        "class-list": "0.1.1"
+        "class-list": "~0.1.1"
       }
     },
     "html-escape": {
@@ -3267,9 +3019,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.2"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "human-time": {
@@ -3282,7 +3034,7 @@
       "resolved": "https://registry.npmjs.org/hypercrop/-/hypercrop-1.1.0.tgz",
       "integrity": "sha1-LI5VoXV+gymsYnkmjmt0x2vNXgg=",
       "requires": {
-        "hyperscript": "1.4.7"
+        "hyperscript": "^1.4.7"
       }
     },
     "hyperfile": {
@@ -3298,7 +3050,7 @@
       "resolved": "https://registry.npmjs.org/hyperlightbox/-/hyperlightbox-1.0.0.tgz",
       "integrity": "sha1-92crMRRJ4S3jcDJTGavFNps/iMk=",
       "requires": {
-        "hyperscript": "1.4.7"
+        "hyperscript": "^1.4.7"
       }
     },
     "hyperscript": {
@@ -3307,8 +3059,8 @@
       "integrity": "sha1-HyPYgPhDbKrCW5GnrDl0e4mnJhg=",
       "requires": {
         "browser-split": "0.0.0",
-        "class-list": "0.1.1",
-        "html-element": "1.3.0"
+        "class-list": "~0.1.0",
+        "html-element": "~1.3.0"
       }
     },
     "hypertabs": {
@@ -3316,7 +3068,7 @@
       "resolved": "https://registry.npmjs.org/hypertabs/-/hypertabs-5.0.1.tgz",
       "integrity": "sha1-4tcHyBmCS+4g2Z8WbqSY13w2JUY=",
       "requires": {
-        "hyperscript": "1.4.7"
+        "hyperscript": "^1.4.7"
       }
     },
     "icss-replace-symbols": {
@@ -3347,7 +3099,7 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "indexof": {
@@ -3360,8 +3112,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -3380,19 +3132,19 @@
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "ansi-regex": "2.1.1",
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "cli-width": "2.2.0",
-        "figures": "1.7.0",
-        "lodash": "4.17.10",
-        "readline2": "1.0.1",
-        "run-async": "0.1.0",
-        "rx-lite": "3.1.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "through": "2.3.8"
+        "ansi-escapes": "^1.1.0",
+        "ansi-regex": "^2.0.0",
+        "chalk": "^1.0.0",
+        "cli-cursor": "^1.0.1",
+        "cli-width": "^2.0.0",
+        "figures": "^1.3.5",
+        "lodash": "^4.3.0",
+        "readline2": "^1.0.1",
+        "run-async": "^0.1.0",
+        "rx-lite": "^3.1.2",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.0",
+        "through": "^2.3.6"
       },
       "dependencies": {
         "through": {
@@ -3420,11 +3172,11 @@
       "dev": true
     },
     "invariant": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "requires": {
-        "loose-envify": "1.3.1"
+        "loose-envify": "^1.0.0"
       }
     },
     "ip": {
@@ -3438,17 +3190,17 @@
       "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y="
     },
     "is-alphabetical": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.1.tgz",
-      "integrity": "sha1-x3B5zJHU76x3W+EDS/LSQ/lebwg="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.2.tgz",
+      "integrity": "sha512-V0xN4BYezDHcBSKb1QHUFMlR4as/XEuCZBzMJUU4n7+Cbt33SmUnSol+pnXFvLxSHNq2CemUXNdaXV6Flg7+xg=="
     },
     "is-alphanumerical": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.1.tgz",
-      "integrity": "sha1-37SqTRCF4zvbYcLe6cgOnGwZ9Ts=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz",
+      "integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
       "requires": {
-        "is-alphabetical": "1.0.1",
-        "is-decimal": "1.0.1"
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0"
       }
     },
     "is-arrayish": {
@@ -3462,13 +3214,13 @@
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "requires": {
-        "binary-extensions": "1.11.0"
+        "binary-extensions": "^1.0.0"
       }
     },
     "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+      "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -3476,7 +3228,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-callable": {
@@ -3490,9 +3242,9 @@
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
     "is-decimal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.1.tgz",
-      "integrity": "sha1-9ftqlJlq2ejjdh+/vQkfH8qMToI="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.2.tgz",
+      "integrity": "sha512-TRzl7mOCchnhchN+f3ICUCzYvL9ul7R+TYOsZ8xia++knyZAJfv/uA1FvQXsAnYIl1T3B2X5E/J7Wb1QXiIBXg=="
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -3509,7 +3261,7 @@
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-extendable": {
@@ -3527,7 +3279,7 @@
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -3535,7 +3287,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-glob": {
@@ -3543,13 +3295,13 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "is-hexadecimal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.1.tgz",
-      "integrity": "sha1-bghLvJIGH7sJcexYts5tQE4k2mk="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz",
+      "integrity": "sha512-but/G3sapV3MNyqiDBLrOi4x8uCIw0RY3o/Vb5GT0sMFHrVV7731wFSVy41T5FO1og7G0gXLJh0MkgPRouko/A=="
     },
     "is-my-ip-valid": {
       "version": "1.0.0",
@@ -3561,10 +3313,10 @@
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
       "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
       "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "is-number": {
@@ -3572,7 +3324,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-path-cwd": {
@@ -3587,7 +3339,7 @@
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.0"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -3596,7 +3348,7 @@
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-plain-obj": {
@@ -3624,7 +3376,7 @@
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "requires": {
-        "has": "1.0.1"
+        "has": "^1.0.1"
       }
     },
     "is-regexp": {
@@ -3638,13 +3390,13 @@
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
       "dev": true,
       "requires": {
-        "tryit": "1.0.3"
+        "tryit": "^1.0.1"
       }
     },
     "is-supported-regexp-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.0.tgz",
-      "integrity": "sha1-i1IMhfrnolM4LUsCZS4EVXbhO7g="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.1.tgz",
+      "integrity": "sha512-3vcJecUUrpgCqc/ca0aWeNu64UGgxcvO60K/Fkr1N6RSvfGCTU60UKN68JDmKokgba0rFFJs12EnzOQa14ubKQ=="
     },
     "is-symbol": {
       "version": "1.0.1",
@@ -3669,9 +3421,9 @@
       "integrity": "sha1-SOcDGfy0MAkjbpazf5hDiJzntRM="
     },
     "is-windows": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.1.tgz",
-      "integrity": "sha1-MQ23D3QtJZoWo2kgK1GvhCMzENk="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
     },
     "isarray": {
       "version": "1.0.0",
@@ -3708,8 +3460,8 @@
       "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.9",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       },
       "dependencies": {
         "esprima": {
@@ -3755,7 +3507,7 @@
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -3769,7 +3521,7 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
       "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
       "requires": {
-        "minimist": "1.2.0"
+        "minimist": "^1.2.0"
       },
       "dependencies": {
         "minimist": {
@@ -3784,7 +3536,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonify": {
@@ -3821,7 +3573,14 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+        }
       }
     },
     "klaw": {
@@ -3830,7 +3589,7 @@
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.9"
       }
     },
     "kvgraph": {
@@ -3843,25 +3602,182 @@
       "resolved": "https://registry.npmjs.org/kvset/-/kvset-1.0.0.tgz",
       "integrity": "sha1-JPaNuOyxVUmMnstWrvQK4kUJhy8="
     },
+    "level": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/level/-/level-3.0.2.tgz",
+      "integrity": "sha512-2qYbbiptPsPWGUI+AgB1gTNXqIjPpALRqrQyNx1zWYNZxhhuzEj/IE4Unu9weEBnsUEocfYe56xOGlAceb8/Fg==",
+      "requires": {
+        "level-packager": "^2.0.2",
+        "leveldown": "^3.0.0",
+        "opencollective-postinstall": "^2.0.0"
+      }
+    },
     "level-codec": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-6.2.0.tgz",
       "integrity": "sha1-pLUkS7akwvcj1oodZOmAxTYn2dQ="
     },
     "level-errors": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
-      "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.1.2.tgz",
+      "integrity": "sha512-Sw/IJwWbPKF5Ai4Wz60B52yj0zYeqzObLh8k1Tk88jVmD51cJSKWSYpRyhVIvFzZdvsPqlH5wfhp/yxdsaQH4w==",
       "requires": {
-        "errno": "0.1.4"
+        "errno": "~0.1.1"
+      }
+    },
+    "level-iterator-stream": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.3.tgz",
+      "integrity": "sha512-I6Heg70nfF+e5Y3/qfthJFexhRw/Gi3bIymCoXAlijZdAcLaPuWSJs3KXyTYf23ID6g0o2QF62Yh+grOXY3Rig==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.5",
+        "xtend": "^4.0.0"
+      }
+    },
+    "level-packager": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-2.1.1.tgz",
+      "integrity": "sha512-6l3G6dVkmdvHwOJrEA9d9hL6SSFrzwjQoLP8HsvohOgfY/8Z9LyTKNCM5Gc84wtsUWCuIHu6r+S6WrCtTWUJCw==",
+      "requires": {
+        "encoding-down": "~4.0.0",
+        "levelup": "^2.0.0"
       }
     },
     "level-post": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.5.tgz",
-      "integrity": "sha1-KmY5BAm/ahYhpES6tvAWREzJgCw=",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.7.tgz",
+      "integrity": "sha512-PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==",
       "requires": {
-        "ltgt": "2.2.0"
+        "ltgt": "^2.1.2"
+      }
+    },
+    "level-sublevel": {
+      "version": "6.6.5",
+      "resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.5.tgz",
+      "integrity": "sha512-SBSR60x+dghhwGUxPKS+BvV1xNqnwsEUBKmnFepPaHJ6VkBXyPK9SImGc3K2BkwBfpxlt7GKkBNlCnrdufsejA==",
+      "requires": {
+        "bytewise": "~1.1.0",
+        "levelup": "~0.19.0",
+        "ltgt": "~2.1.1",
+        "pull-defer": "^0.2.2",
+        "pull-level": "^2.0.3",
+        "pull-stream": "^3.6.8",
+        "typewiselite": "~1.0.0",
+        "xtend": "~4.0.0"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "0.12.4",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
+          "integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
+          "requires": {
+            "xtend": "~3.0.0"
+          },
+          "dependencies": {
+            "xtend": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+              "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
+            }
+          }
+        },
+        "bl": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
+          "integrity": "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=",
+          "requires": {
+            "readable-stream": "~1.0.26"
+          }
+        },
+        "deferred-leveldown": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-0.2.0.tgz",
+          "integrity": "sha1-LO8fER4cV4cNi7uK8mUOWHzS9bQ=",
+          "requires": {
+            "abstract-leveldown": "~0.12.1"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "levelup": {
+          "version": "0.19.1",
+          "resolved": "https://registry.npmjs.org/levelup/-/levelup-0.19.1.tgz",
+          "integrity": "sha1-86anIFJyxLXzXkEv8ASgOgrt9Qs=",
+          "requires": {
+            "bl": "~0.8.1",
+            "deferred-leveldown": "~0.2.0",
+            "errno": "~0.1.1",
+            "prr": "~0.0.0",
+            "readable-stream": "~1.0.26",
+            "semver": "~5.1.0",
+            "xtend": "~3.0.0"
+          },
+          "dependencies": {
+            "xtend": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+              "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
+            }
+          }
+        },
+        "ltgt": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
+          "integrity": "sha1-EIUaBtmWS5cReEQcI8nlJpjuzjQ="
+        },
+        "prr": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+          "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "semver": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.1.tgz",
+          "integrity": "sha1-oykqNz5vPgeY2gsgZBuanFvEfhk="
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
+    "leveldown": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-3.0.2.tgz",
+      "integrity": "sha512-+ANRScj1npQQzv6e4DYAKRjVQZZ+ahMoubKrNP68nIq+l9bYgb+WiXF+14oTcQTg2f7qE9WHGW7rBG9nGSsA+A==",
+      "requires": {
+        "abstract-leveldown": "~4.0.0",
+        "bindings": "~1.3.0",
+        "fast-future": "~1.0.2",
+        "nan": "~2.10.0",
+        "prebuild-install": "^4.0.0"
+      }
+    },
+    "levelup": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-2.0.2.tgz",
+      "integrity": "sha512-us+nTLUyd/eLnclYYddOCdAVw1hnymGx/9p4Jr5ThohStsjLqMVmbYiz6/SYFZEPXNF+AKQSvh6fA2e2KZpC8w==",
+      "requires": {
+        "deferred-leveldown": "~3.0.0",
+        "level-errors": "~1.1.0",
+        "level-iterator-stream": "~2.0.0",
+        "xtend": "~4.0.0"
       }
     },
     "levn": {
@@ -3870,8 +3786,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "libnested": {
@@ -3880,16 +3796,16 @@
       "integrity": "sha512-YvMQglpk/DyB8vFL5usJe6IZTqOU/fRopoUpoOt9TavYh5CaGdTp6zYqrA7DW8tHmZAr8fj+pDXbHBwlVrcVXQ=="
     },
     "libsodium": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.2.12.tgz",
-      "integrity": "sha1-gwg1ZNzwicuCpQNb6Sul0iSizN4="
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.3.tgz",
+      "integrity": "sha512-ld+deUNqSsZYbAobUs63UyduPq8ICp/Ul/5lbvBIYpuSNWpPRU0PIxbW+xXipVZtuopR6fIz9e0tTnNuPMNeqw=="
     },
     "libsodium-wrappers": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.2.12.tgz",
-      "integrity": "sha1-UftQd0uO3FF5J7MHuBKkbDpGfh4=",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.3.tgz",
+      "integrity": "sha512-dw5Jh6TZ5qc5rQVZe3JrSO/J05CE+DmAPnqD7Q2glBUE969xZ6o3fchnUxyPlp6ss3x0MFxmdJntveFN+XTg1g==",
       "requires": {
-        "libsodium": "0.2.12"
+        "libsodium": "0.7.3"
       }
     },
     "load-json-file": {
@@ -3898,11 +3814,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
       }
     },
     "lodash": {
@@ -3915,8 +3831,8 @@
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash._basecopy": {
@@ -3934,9 +3850,9 @@
       "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
       "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
       "requires": {
-        "lodash._bindcallback": "3.0.1",
-        "lodash._isiterateecall": "3.0.9",
-        "lodash.restparam": "3.6.1"
+        "lodash._bindcallback": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0",
+        "lodash.restparam": "^3.0.0"
       }
     },
     "lodash._getnative": {
@@ -3954,9 +3870,9 @@
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
       "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
       "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._createassigner": "3.1.1",
-        "lodash.keys": "3.1.2"
+        "lodash._baseassign": "^3.0.0",
+        "lodash._createassigner": "^3.0.0",
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash.clonedeep": {
@@ -3984,9 +3900,9 @@
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "lodash.map": {
@@ -3995,9 +3911,9 @@
       "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM="
     },
     "lodash.merge": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
-      "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU="
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
     },
     "lodash.mergewith": {
       "version": "4.6.1",
@@ -4024,7 +3940,7 @@
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
       "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
       "requires": {
-        "chalk": "1.1.3"
+        "chalk": "^1.0.0"
       }
     },
     "log-update": {
@@ -4032,8 +3948,8 @@
       "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
       "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "cli-cursor": "1.0.2"
+        "ansi-escapes": "^1.0.0",
+        "cli-cursor": "^1.0.2"
       }
     },
     "longest-streak": {
@@ -4047,11 +3963,11 @@
       "integrity": "sha1-dwat7VmpntygbmtUu4bI7BnJUVU="
     },
     "loose-envify": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "requires": {
-        "js-tokens": "3.0.2"
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
     "lossy-store": {
@@ -4059,8 +3975,8 @@
       "resolved": "https://registry.npmjs.org/lossy-store/-/lossy-store-1.2.3.tgz",
       "integrity": "sha1-Vi4qkgPYZh9g6HEt5Af72t8nXck=",
       "requires": {
-        "mkdirp": "0.5.1",
-        "tape": "4.9.1"
+        "mkdirp": "^0.5.1",
+        "tape": "^4.6.3"
       }
     },
     "loud-rejection": {
@@ -4069,17 +3985,17 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
       }
     },
     "lru-cache": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "lrucache": {
@@ -4088,19 +4004,19 @@
       "integrity": "sha1-Ox3tDRuoLhiLm9q6nu5khvhkpDQ="
     },
     "ltgt": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.0.tgz",
-      "integrity": "sha1-tlul/LNJopkkyOMz98alVi8uSEI="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+      "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
     },
     "map-filter-reduce": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/map-filter-reduce/-/map-filter-reduce-2.2.1.tgz",
       "integrity": "sha1-YysSfDrl1q2eIc/dlpG2O4lE/NI=",
       "requires": {
-        "binary-search": "1.3.2",
+        "binary-search": "^1.2.0",
         "pull-sink-through": "0.0.0",
-        "pull-stream": "3.6.8",
-        "typewiselite": "1.0.0"
+        "pull-stream": "^3.3.0",
+        "typewiselite": "^1.0.0"
       }
     },
     "map-merge": {
@@ -4119,15 +4035,20 @@
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-0.4.0.tgz",
       "integrity": "sha1-iQwsGzv+g/sA5BKbjkz+ZFJw+dE="
     },
+    "math-random": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
+    },
     "mdmanifest": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/mdmanifest/-/mdmanifest-1.0.8.tgz",
       "integrity": "sha1-wEiRiDwoyDYC4dBrBaEQN+NZtMg=",
       "requires": {
-        "minimist": "1.2.0",
-        "remark": "3.2.3",
-        "remark-html": "2.0.2",
-        "word-wrap": "1.2.3"
+        "minimist": "^1.2.0",
+        "remark": "^3.2.2",
+        "remark-html": "^2.0.2",
+        "word-wrap": "^1.1.0"
       },
       "dependencies": {
         "minimist": {
@@ -4143,16 +4064,16 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "1.2.0",
-        "normalize-package-data": "2.4.0",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
       },
       "dependencies": {
         "minimist": {
@@ -4168,7 +4089,7 @@
       "resolved": "https://registry.npmjs.org/micro-css/-/micro-css-2.0.1.tgz",
       "integrity": "sha1-qE1+KmpKtzRpbYWDa52DrHnGj7g=",
       "requires": {
-        "optimist": "0.6.1"
+        "optimist": "^0.6.1"
       }
     },
     "micromatch": {
@@ -4176,25 +4097,25 @@
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.4"
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
       }
     },
     "mime": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.5.0.tgz",
-      "integrity": "sha512-v/jMDoK/qKptnTuC3YUNbIj8uUYvTCIHzVu9BHldKSWja48wusAtfjlcBlqnFrqClu3yf69ScDxBPrIyFnF51g=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
       "version": "1.35.0",
@@ -4208,20 +4129,20 @@
       "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
       "dev": true,
       "requires": {
-        "mime-db": "1.35.0"
+        "mime-db": "~1.35.0"
       }
     },
     "mimic-response": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz",
-      "integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -4262,22 +4183,22 @@
       "resolved": "https://registry.npmjs.org/multiblob/-/multiblob-1.13.0.tgz",
       "integrity": "sha1-4oTV5KlE5yS+4uOJbLMAfwaaQbs=",
       "requires": {
-        "blake2s": "1.0.1",
-        "cont": "1.0.3",
-        "explain-error": "1.0.4",
-        "mkdirp": "0.5.1",
-        "pull-cat": "1.1.11",
-        "pull-defer": "0.2.2",
-        "pull-file": "0.5.0",
-        "pull-glob": "1.0.6",
-        "pull-live": "1.0.1",
-        "pull-notify": "0.1.1",
-        "pull-paramap": "1.2.2",
-        "pull-stream": "3.6.8",
-        "pull-write-file": "0.2.4",
-        "rc": "0.5.5",
-        "rimraf": "2.2.8",
-        "stream-to-pull-stream": "1.7.2"
+        "blake2s": "~1.0.1",
+        "cont": "~1.0.1",
+        "explain-error": "~1.0.1",
+        "mkdirp": "~0.5.0",
+        "pull-cat": "^1.1.8",
+        "pull-defer": "^0.2.2",
+        "pull-file": "^0.5.0",
+        "pull-glob": "~1.0.6",
+        "pull-live": "^1.0.0",
+        "pull-notify": "^0.1.1",
+        "pull-paramap": "^1.2.2",
+        "pull-stream": "^3.6.2",
+        "pull-write-file": "^0.2.1",
+        "rc": "~0.5.4",
+        "rimraf": "~2.2.8",
+        "stream-to-pull-stream": "^1.7.2"
       },
       "dependencies": {
         "deep-extend": {
@@ -4290,7 +4211,7 @@
           "resolved": "https://registry.npmjs.org/pull-file/-/pull-file-0.5.0.tgz",
           "integrity": "sha1-s8pAUwbggvnUUoKIkzutsrZWNls=",
           "requires": {
-            "pull-utf8-decoder": "1.0.2"
+            "pull-utf8-decoder": "^1.0.2"
           }
         },
         "rc": {
@@ -4298,10 +4219,10 @@
           "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.5.tgz",
           "integrity": "sha1-VBzDMA9GS23+ZDLXVvDy3T6esZk=",
           "requires": {
-            "deep-extend": "0.2.11",
-            "ini": "1.3.5",
-            "minimist": "0.0.8",
-            "strip-json-comments": "0.1.3"
+            "deep-extend": "~0.2.5",
+            "ini": "~1.3.0",
+            "minimist": "~0.0.7",
+            "strip-json-comments": "0.1.x"
           }
         },
         "rimraf": {
@@ -4321,8 +4242,8 @@
       "resolved": "https://registry.npmjs.org/multiblob-http/-/multiblob-http-0.4.2.tgz",
       "integrity": "sha512-hVaXryaqJ3vvKjRNcOCEadzgO99nR+haxlptswr3vRvgavbK/Y/I7/Nat12WIQno2/A8+nkbE+ZcrsN3UDbtQw==",
       "requires": {
-        "pull-stream": "3.6.8",
-        "stream-to-pull-stream": "1.7.2"
+        "pull-stream": "^3.4.3",
+        "stream-to-pull-stream": "^1.7.0"
       }
     },
     "multicb": {
@@ -4331,17 +4252,17 @@
       "integrity": "sha512-PZM4dhYFmCF6uZGWpEmoPMUqJBywS9IcAgybT2GmSpYI1BvGvoWSdbio+ik+q/YD2vodhvslESWIS3NnkKYdqQ=="
     },
     "multiserver": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/multiserver/-/multiserver-1.10.0.tgz",
-      "integrity": "sha1-0pig0AKOClhvkLufyURoTUI5D4g=",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/multiserver/-/multiserver-1.12.0.tgz",
+      "integrity": "sha512-vyoVDqxiJabvepIKYN2+lYcPDcV5/de54kWXg1nYa1VK0NMJZ+gVIS6bLnQ9FmNzOxpCmVrVOkaQ0pMlMic5Ow==",
       "requires": {
-        "pull-cat": "1.1.11",
-        "pull-stream": "3.6.8",
-        "pull-ws": "3.3.0",
-        "secret-handshake": "1.1.11",
+        "pull-cat": "~1.1.5",
+        "pull-stream": "^3.6.1",
+        "pull-ws": "^3.3.0",
+        "secret-handshake": "^1.1.12",
         "separator-escape": "0.0.0",
         "socks": "1.1.9",
-        "stream-to-pull-stream": "1.7.2"
+        "stream-to-pull-stream": "^1.7.2"
       }
     },
     "mutant": {
@@ -4350,7 +4271,7 @@
       "integrity": "sha1-kEh1RvcAs8KKqApD0c99M48wdYE=",
       "requires": {
         "browser-split": "0.0.1",
-        "xtend": "4.0.1"
+        "xtend": "^4.0.1"
       },
       "dependencies": {
         "browser-split": {
@@ -4365,9 +4286,9 @@
       "resolved": "https://registry.npmjs.org/mutant-pull-reduce/-/mutant-pull-reduce-1.1.0.tgz",
       "integrity": "sha1-lvdwJ7QABhNkrL8mM74ugtVEDmo=",
       "requires": {
-        "mutant": "3.22.1",
+        "mutant": "^3.14.1",
         "pull-pause": "0.0.0",
-        "pull-stream": "3.6.8"
+        "pull-stream": "^3.5.0"
       }
     },
     "mutant-scroll": {
@@ -4375,10 +4296,10 @@
       "resolved": "https://registry.npmjs.org/mutant-scroll/-/mutant-scroll-1.0.2.tgz",
       "integrity": "sha512-0ZrtqOd8dNJyV/P105JEazyI/a7sUV8U7XKJNmkB5LCBSC21xupgA/we6YJp5cuNvxmN5RVONEqXAI6GIn8mgw==",
       "requires": {
-        "lodash.throttle": "4.1.1",
-        "mutant": "3.22.1",
+        "lodash.throttle": "^4.1.1",
+        "mutant": "^3.22.1",
         "pull-pause": "0.0.1",
-        "pull-stream": "3.6.8"
+        "pull-stream": "^3.6.1"
       },
       "dependencies": {
         "pull-pause": {
@@ -4399,11 +4320,11 @@
       "resolved": "https://registry.npmjs.org/muxrpc/-/muxrpc-6.4.0.tgz",
       "integrity": "sha1-JPfaBpvUYpsHfpk7BXeUKyaI6ug=",
       "requires": {
-        "explain-error": "1.0.4",
-        "packet-stream": "2.0.2",
-        "packet-stream-codec": "1.1.2",
-        "pull-goodbye": "0.0.2",
-        "pull-stream": "3.6.8"
+        "explain-error": "^1.0.1",
+        "packet-stream": "~2.0.0",
+        "packet-stream-codec": "^1.1.1",
+        "pull-goodbye": "~0.0.1",
+        "pull-stream": "^3.2.3"
       }
     },
     "muxrpc-validation": {
@@ -4411,8 +4332,8 @@
       "resolved": "https://registry.npmjs.org/muxrpc-validation/-/muxrpc-validation-2.0.1.tgz",
       "integrity": "sha1-zWUNFyAl/p0GQjCqs4ymMo3Rby8=",
       "requires": {
-        "pull-stream": "2.28.4",
-        "zerr": "1.0.4"
+        "pull-stream": "^2.28.3",
+        "zerr": "^1.0.1"
       },
       "dependencies": {
         "pull-stream": {
@@ -4420,7 +4341,7 @@
           "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-2.28.4.tgz",
           "integrity": "sha1-fql0E8FhnCC8O9+eEOkTR7AyU+Q=",
           "requires": {
-            "pull-core": "1.1.0"
+            "pull-core": "~1.1.0"
           }
         }
       }
@@ -4430,10 +4351,10 @@
       "resolved": "https://registry.npmjs.org/muxrpcli/-/muxrpcli-1.1.0.tgz",
       "integrity": "sha1-Sum6mGq4JcSlwS/LccbaqB6rUVg=",
       "requires": {
-        "minimist": "1.2.0",
-        "pull-stream": "2.28.4",
-        "stream-to-pull-stream": "1.7.2",
-        "word-wrap": "1.2.3"
+        "minimist": "^1.2.0",
+        "pull-stream": "^2.28.3",
+        "stream-to-pull-stream": "^1.6.6",
+        "word-wrap": "^1.1.0"
       },
       "dependencies": {
         "minimist": {
@@ -4446,7 +4367,7 @@
           "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-2.28.4.tgz",
           "integrity": "sha1-fql0E8FhnCC8O9+eEOkTR7AyU+Q=",
           "requires": {
-            "pull-core": "1.1.0"
+            "pull-core": "~1.1.0"
           }
         }
       }
@@ -4456,9 +4377,9 @@
       "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
       "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
       "requires": {
-        "mkdirp": "0.5.1",
-        "ncp": "2.0.0",
-        "rimraf": "2.4.5"
+        "mkdirp": "~0.5.1",
+        "ncp": "~2.0.0",
+        "rimraf": "~2.4.0"
       },
       "dependencies": {
         "glob": {
@@ -4466,11 +4387,11 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "rimraf": {
@@ -4478,16 +4399,15 @@
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
           "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
           "requires": {
-            "glob": "6.0.4"
+            "glob": "^6.0.1"
           }
         }
       }
     },
     "nan": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
-      "optional": true
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -4505,28 +4425,29 @@
       "resolved": "https://registry.npmjs.org/neodoc/-/neodoc-1.4.0.tgz",
       "integrity": "sha1-Uwyph33gcp/9XWQg+1KxBPCIjQU=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "node-abi": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.4.3.tgz",
+      "integrity": "sha512-b656V5C0628gOOA2kwcpNA/bxdlqYF9FvxJ+qqVX0ctdXNVZpS8J6xEUYir3WAKc7U0BH/NRlSpNbGsy+azjeg==",
+      "requires": {
+        "semver": "^5.4.1"
       }
     },
     "node-gyp-build": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.2.2.tgz",
-      "integrity": "sha512-t8W/0UqFGl1c+5ORA3NoT3npU+PxWBL9iPhY7ZySSTszodj3RWexmu8niayWBE0v+0DLARvOXsjaAvfmSEQOyQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.4.0.tgz",
+      "integrity": "sha512-YoviGBJYGrPdLOKDIQB0sKxuKy/EEsxzooNkOZak4vSTKT/qH0Pa6dj3t1MJjEQGsefih61IyHDmO1WW7xOFfw==",
       "optional": true
     },
     "non-private-ip": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/non-private-ip/-/non-private-ip-1.4.2.tgz",
-      "integrity": "sha1-7VH6e/fpGpxjI5TxBUe2o5Xovq0=",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/non-private-ip/-/non-private-ip-1.4.4.tgz",
+      "integrity": "sha512-K9nTVFOGUOYutaG8ywiKpCdVu458RFxSgSJ0rribUxtf5iLM9B2+raFJgkID3p5op0+twmoQqFaPnu9KYz6qzg==",
       "requires": {
-        "ip": "0.3.3"
-      },
-      "dependencies": {
-        "ip": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/ip/-/ip-0.3.3.tgz",
-          "integrity": "sha1-jugwnpLwsEDSh/cu+soaIXAtP7Q="
-        }
+        "ip": "^1.1.5"
       }
     },
     "noop-logger": {
@@ -4540,10 +4461,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.7.1",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.4.1",
-        "validate-npm-package-license": "3.0.3"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -4551,22 +4472,22 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "normalize-uri": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/normalize-uri/-/normalize-uri-1.1.0.tgz",
-      "integrity": "sha1-AftEDH/QWbnZvoZFqsFDQe/QWd0="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-uri/-/normalize-uri-1.1.1.tgz",
+      "integrity": "sha512-bui9/kzRGymbkxJsZEBZgDHK2WJWGOHzR0pCr404EpkpVFTkCOYaRwQTlehUE+7oI70mWNENncCWqUxT/icfHw=="
     },
     "npm-prefix": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/npm-prefix/-/npm-prefix-1.2.0.tgz",
       "integrity": "sha1-5hlFX3B0ulTMZtbQ033Z8b5ry8A=",
       "requires": {
-        "rc": "1.2.2",
-        "shellsubstitute": "1.2.0",
-        "untildify": "2.1.0"
+        "rc": "^1.1.0",
+        "shellsubstitute": "^1.1.0",
+        "untildify": "^2.1.0"
       }
     },
     "npmlog": {
@@ -4574,10 +4495,10 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "requires": {
-        "are-we-there-yet": "1.1.4",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "nugget": {
@@ -4586,12 +4507,12 @@
       "integrity": "sha1-IBCVpIfhrTYIGzQy+jytpPjQcbA=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "minimist": "1.2.0",
-        "pretty-bytes": "1.0.4",
-        "progress-stream": "1.2.0",
-        "request": "2.87.0",
-        "single-line-log": "1.1.2",
+        "debug": "^2.1.3",
+        "minimist": "^1.1.0",
+        "pretty-bytes": "^1.0.2",
+        "progress-stream": "^1.1.0",
+        "request": "^2.45.0",
+        "single-line-log": "^1.1.2",
         "throttleit": "0.0.2"
       },
       "dependencies": {
@@ -4625,17 +4546,17 @@
       "integrity": "sha1-9RV8EWwUVbJDsG7pdwM5LFrYn+w="
     },
     "object-keys": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
     },
     "object.omit": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       }
     },
     "observ": {
@@ -4648,7 +4569,7 @@
       "resolved": "https://registry.npmjs.org/observ-debounce/-/observ-debounce-1.1.1.tgz",
       "integrity": "sha1-ME6XyFrdpw7NfwjaRQZ475Dwtwc=",
       "requires": {
-        "observ": "0.2.0"
+        "observ": "~0.2.0"
       }
     },
     "obv": {
@@ -4671,7 +4592,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -4694,8 +4615,8 @@
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "requires": {
-        "minimist": "0.0.8",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       }
     },
     "optionator": {
@@ -4704,12 +4625,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       },
       "dependencies": {
         "wordwrap": {
@@ -4735,18 +4656,27 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
+    },
     "packet-stream": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/packet-stream/-/packet-stream-2.0.2.tgz",
-      "integrity": "sha1-uQt/m6tKliQiy8nLJHGcNT5JMmc="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/packet-stream/-/packet-stream-2.0.4.tgz",
+      "integrity": "sha512-7+oxHdMMs6VhLvvbrDUc8QNuelE9fPKLDdToXBIKLPKOlnoBeMim+/35edp+AnFTLzk3xcogVvQ/jrZyyGsEiw=="
     },
     "packet-stream-codec": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/packet-stream-codec/-/packet-stream-codec-1.1.2.tgz",
       "integrity": "sha1-ebMC/BRM37tKtv66cEDmpdmcecc=",
       "requires": {
-        "pull-reader": "1.2.9",
-        "pull-through": "1.0.18"
+        "pull-reader": "^1.2.4",
+        "pull-through": "^1.0.17"
       }
     },
     "pako": {
@@ -4755,16 +4685,16 @@
       "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
     },
     "parse-entities": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.1.1.tgz",
-      "integrity": "sha1-gRLYhHExnyerrk1klksSL+ThuJA=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.1.2.tgz",
+      "integrity": "sha512-5N9lmQ7tmxfXf+hO3X6KRG6w7uYO/HL9fHalSySTdyn63C3WNvTM/1R8tn1u1larNcEbo3Slcy2bsVDQqvEpUg==",
       "requires": {
-        "character-entities": "1.2.1",
-        "character-entities-legacy": "1.1.1",
-        "character-reference-invalid": "1.1.1",
-        "is-alphanumerical": "1.0.1",
-        "is-decimal": "1.0.1",
-        "is-hexadecimal": "1.0.1"
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
       }
     },
     "parse-glob": {
@@ -4772,10 +4702,10 @@
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "parse-json": {
@@ -4784,7 +4714,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.2"
+        "error-ex": "^1.2.0"
       }
     },
     "patch-book": {
@@ -4792,18 +4722,18 @@
       "resolved": "https://registry.npmjs.org/patch-book/-/patch-book-1.0.16.tgz",
       "integrity": "sha512-+7zPoC430u8FXXw5VE0wEOVPqUKEq+5dCjZEU4W4suqbKCCMiivWeDgGQ5MIq51LF6lgFaJ78uA9BnvN7eKHcA==",
       "requires": {
-        "bulk-require": "1.0.1",
-        "deep-equal": "1.0.1",
-        "depnest": "1.3.0",
-        "html-escape": "2.0.0",
-        "monotonic-timestamp": "0.0.9",
-        "mutant": "3.22.1",
-        "pull-many": "1.0.8",
-        "pull-scroll": "1.0.9",
-        "pull-sort": "1.0.1",
-        "pull-stream": "3.6.8",
-        "read-directory": "3.0.0",
-        "suggest-box": "2.2.3"
+        "bulk-require": "^1.0.1",
+        "deep-equal": "^1.0.1",
+        "depnest": "^1.3.0",
+        "html-escape": "^2.0.0",
+        "monotonic-timestamp": "^0.0.9",
+        "mutant": "^3.22.1",
+        "pull-many": "^1.0.8",
+        "pull-scroll": "^1.0.9",
+        "pull-sort": "^1.0.1",
+        "pull-stream": "^3.6.1",
+        "read-directory": "^3.0.0",
+        "suggest-box": "^2.2.3"
       },
       "dependencies": {
         "read-directory": {
@@ -4811,11 +4741,11 @@
           "resolved": "https://registry.npmjs.org/read-directory/-/read-directory-3.0.0.tgz",
           "integrity": "sha512-D9aGTSoUm2AxxEX8brBkGOB7GZ7/Opv5AuQCz0VRsccPV2WwsEoRpN5bRPGi/XhRF00SRYhpgwI14Uk7QsPbEA==",
           "requires": {
-            "defaults": "1.0.3",
-            "each-async": "1.1.1",
-            "glob": "7.1.2",
-            "static-module": "1.5.0",
-            "through2": "2.0.3"
+            "defaults": "^1.0.3",
+            "each-async": "^1.1.1",
+            "glob": "^7.1.2",
+            "static-module": "^1.3.2",
+            "through2": "^2.0.3"
           }
         },
         "through2": {
@@ -4823,8 +4753,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "requires": {
-            "readable-stream": "2.3.3",
-            "xtend": "4.0.1"
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -4834,7 +4764,7 @@
       "resolved": "https://registry.npmjs.org/patch-context/-/patch-context-2.0.1.tgz",
       "integrity": "sha1-JLiEM2Rr+9e4+EkGFEKJeTQcxuY=",
       "requires": {
-        "is-electron": "2.1.0"
+        "is-electron": "^2.0.0"
       }
     },
     "patch-drafts": {
@@ -4842,8 +4772,8 @@
       "resolved": "https://registry.npmjs.org/patch-drafts/-/patch-drafts-0.0.6.tgz",
       "integrity": "sha512-C0uezBJ/TymZO4swd1qOD4MqghhQCNCshB3tHjRCl5f2tvj3KLQ8vwMsD8kQrbKwxdS4h6uxYBSazFG/Q56l6g==",
       "requires": {
-        "depnest": "1.3.0",
-        "lodash.merge": "4.6.0"
+        "depnest": "^1.3.0",
+        "lodash.merge": "^4.6.0"
       }
     },
     "patch-gatherings": {
@@ -4851,21 +4781,21 @@
       "resolved": "https://registry.npmjs.org/patch-gatherings/-/patch-gatherings-2.4.7.tgz",
       "integrity": "sha512-N+0OuPsh0DjgMefzPKc1XHlsih4lcG7PpVTxaN1qAhSwcEfmBaOikcbQk1WHx+RNO5yBsWwM6EmyAouvq9IXDg==",
       "requires": {
-        "bulk-require": "1.0.1",
-        "cssify": "1.0.3",
-        "depject": "4.1.1",
-        "depnest": "1.3.0",
-        "flatpickr": "2.6.3",
-        "insert-css": "2.0.0",
-        "libnested": "1.3.2",
-        "moment": "2.22.2",
-        "mutant": "3.22.1",
-        "pull-notify": "0.1.1",
-        "pull-scroll": "1.0.9",
-        "read-directory": "2.1.1",
-        "spacetime": "1.3.3",
-        "ssb-ref": "2.8.0",
-        "suggest-box": "2.2.3"
+        "bulk-require": "^1.0.0",
+        "cssify": "^1.0.3",
+        "depject": "^4.1.0",
+        "depnest": "^1.3.0",
+        "flatpickr": "^2.6.1",
+        "insert-css": "^2.0.0",
+        "libnested": "^1.2.1",
+        "moment": "^2.18.0",
+        "mutant": "^3.18.0",
+        "pull-notify": "^0.1.1",
+        "pull-scroll": "^1.0.3",
+        "read-directory": "^2.0.0",
+        "spacetime": "^1.0.4",
+        "ssb-ref": "^2.7.1",
+        "suggest-box": "^2.2.3"
       }
     },
     "patch-history": {
@@ -4873,20 +4803,10 @@
       "resolved": "https://registry.npmjs.org/patch-history/-/patch-history-1.0.0.tgz",
       "integrity": "sha512-lWc3U5awYkuZIBLiRcDgagtilCEQwb2IN3UAorVrIzdp4+MkyrVH3MQmVazx4YLV4w9AkVUy5Fdyz3yn8v32iw==",
       "requires": {
-        "depject": "4.1.1",
-        "depnest": "1.3.0",
-        "lodash": "4.17.10",
-        "mutant": "3.22.1"
-      },
-      "dependencies": {
-        "depject": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/depject/-/depject-4.1.1.tgz",
-          "integrity": "sha1-6/ciCGgsEfx9BRIjxG6223jVYFg=",
-          "requires": {
-            "libnested": "1.3.2"
-          }
-        }
+        "depject": "^4.1.0",
+        "depnest": "^1.3.0",
+        "lodash": "^4.17.4",
+        "mutant": "^3.21.2"
       }
     },
     "patch-hub": {
@@ -4894,24 +4814,24 @@
       "resolved": "https://registry.npmjs.org/patch-hub/-/patch-hub-1.1.0.tgz",
       "integrity": "sha512-rIt7OI68eiYS4abcDCttt9KaIL7s4ZHRvG3+c9u9/mZqwQ/aJbcANcFI6ukH7em5sT839i3yk/c0f0VSVHb6tw==",
       "requires": {
-        "asyncmemo": "1.0.0",
-        "bulk-require": "1.0.1",
-        "depnest": "1.3.0",
-        "emoji-named-characters": "1.0.2",
-        "highlight.js": "9.12.0",
-        "libnested": "1.3.2",
-        "lrucache": "1.0.3",
-        "mutant": "3.22.1",
-        "pull-git-repo": "1.2.1",
-        "pull-next": "1.0.1",
-        "pull-scroll": "1.0.9",
-        "pull-stream": "3.6.8",
-        "read-directory": "2.1.1",
-        "ssb-avatar": "0.2.0",
-        "ssb-git-repo": "2.8.3",
-        "ssb-marked": "0.7.2",
-        "ssb-ref": "2.8.0",
-        "xtend": "4.0.1"
+        "asyncmemo": "^1.0.0",
+        "bulk-require": "^1.0.0",
+        "depnest": "^1.3.0",
+        "emoji-named-characters": "^1.0.2",
+        "highlight.js": "^9.12.0",
+        "libnested": "^1.2.1",
+        "lrucache": "^1.0.2",
+        "mutant": "^3.19.0",
+        "pull-git-repo": "^1.2.0",
+        "pull-next": "^1.0.0",
+        "pull-scroll": "^1.0.4",
+        "pull-stream": "^3.5.0",
+        "read-directory": "^2.0.0",
+        "ssb-avatar": "^0.2.0",
+        "ssb-git-repo": "^2.8.1",
+        "ssb-marked": "^0.7.2",
+        "ssb-ref": "^2.7.1",
+        "xtend": "^4.0.1"
       }
     },
     "patch-inbox": {
@@ -4919,16 +4839,16 @@
       "resolved": "https://registry.npmjs.org/patch-inbox/-/patch-inbox-1.1.6.tgz",
       "integrity": "sha512-R/NZmGJNddEMLnQrPo9tTULQr3aTwo1CS4cv+3EYbuFilJ1zXMYn9DobPLBGZyIfXafEahsEUb2CS0p0MhIgPg==",
       "requires": {
-        "depnest": "1.3.0",
-        "libnested": "1.3.2",
-        "mutant": "3.22.1",
-        "pull-next-query": "1.0.0",
-        "pull-scroll": "1.0.9",
-        "pull-stream": "3.6.8",
-        "read-directory": "3.0.0",
-        "ssb-mentions": "0.5.0",
-        "ssb-ref": "2.11.1",
-        "suggest-box": "2.2.3"
+        "depnest": "^1.3.0",
+        "libnested": "^1.3.2",
+        "mutant": "^3.21.2",
+        "pull-next-query": "^1.0.0",
+        "pull-scroll": "^1.0.9",
+        "pull-stream": "^3.6.1",
+        "read-directory": "^3.0.0",
+        "ssb-mentions": "^0.5.0",
+        "ssb-ref": "^2.11.1",
+        "suggest-box": "^2.2.3"
       },
       "dependencies": {
         "read-directory": {
@@ -4936,20 +4856,11 @@
           "resolved": "https://registry.npmjs.org/read-directory/-/read-directory-3.0.0.tgz",
           "integrity": "sha512-D9aGTSoUm2AxxEX8brBkGOB7GZ7/Opv5AuQCz0VRsccPV2WwsEoRpN5bRPGi/XhRF00SRYhpgwI14Uk7QsPbEA==",
           "requires": {
-            "defaults": "1.0.3",
-            "each-async": "1.1.1",
-            "glob": "7.1.2",
-            "static-module": "1.5.0",
-            "through2": "2.0.3"
-          }
-        },
-        "ssb-ref": {
-          "version": "2.11.1",
-          "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.11.1.tgz",
-          "integrity": "sha512-K3L9hJ1v0HrH8abtEKiBkdeabHVaws+CS81mZqUfhR84i0dlYhiIIDwqeLxUj/1mLcsZPF3gMKPsFCUr7UAdMA==",
-          "requires": {
-            "ip": "1.1.5",
-            "is-valid-domain": "0.0.5"
+            "defaults": "^1.0.3",
+            "each-async": "^1.1.1",
+            "glob": "^7.1.2",
+            "static-module": "^1.3.2",
+            "through2": "^2.0.3"
           }
         },
         "through2": {
@@ -4957,8 +4868,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "requires": {
-            "readable-stream": "2.3.3",
-            "xtend": "4.0.1"
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -4968,13 +4879,13 @@
       "resolved": "https://registry.npmjs.org/patch-settings/-/patch-settings-1.1.2.tgz",
       "integrity": "sha512-1mseZALkF1AQ3MMWLkymdZ/gcJIPDmYj6UB1XHM+JXqiU6u2slFJ8xjXQyfy/UEx+3+jACr1sMkUu9hT6jtEHA==",
       "requires": {
-        "deep-equal": "1.0.1",
-        "depnest": "1.3.0",
-        "lodash.get": "4.4.2",
-        "lodash.merge": "4.6.0",
-        "lodash.mergewith": "4.6.1",
-        "lodash.set": "4.3.2",
-        "mutant": "3.22.1"
+        "deep-equal": "^1.0.1",
+        "depnest": "^1.3.0",
+        "lodash.get": "^4.4.2",
+        "lodash.merge": "^4.6.0",
+        "lodash.mergewith": "^4.6.1",
+        "lodash.set": "^4.3.2",
+        "mutant": "^3.21.2"
       }
     },
     "patch-suggest": {
@@ -4982,21 +4893,10 @@
       "resolved": "https://registry.npmjs.org/patch-suggest/-/patch-suggest-2.0.2.tgz",
       "integrity": "sha512-I9jdQVvLNX5dZw8E2nz8BGDT2D5N39Qb/mprE2mEsz+VX/5b+yuuwA6BxhGuiyQtKqHNwugnxOpEG4P7u2fW1Q==",
       "requires": {
-        "depnest": "1.3.0",
-        "lodash.map": "4.6.0",
-        "mutant": "3.22.1",
-        "ssb-ref": "2.11.1"
-      },
-      "dependencies": {
-        "ssb-ref": {
-          "version": "2.11.1",
-          "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.11.1.tgz",
-          "integrity": "sha512-K3L9hJ1v0HrH8abtEKiBkdeabHVaws+CS81mZqUfhR84i0dlYhiIIDwqeLxUj/1mLcsZPF3gMKPsFCUr7UAdMA==",
-          "requires": {
-            "ip": "1.1.5",
-            "is-valid-domain": "0.0.5"
-          }
-        }
+        "depnest": "^1.3.0",
+        "lodash.map": "^4.6.0",
+        "mutant": "^3.22.1",
+        "ssb-ref": "^2.11.1"
       }
     },
     "patchbay-book": {
@@ -5004,7 +4904,7 @@
       "resolved": "https://registry.npmjs.org/patchbay-book/-/patchbay-book-1.0.8.tgz",
       "integrity": "sha512-w4luWV+bbfAOKlqvVIsaCe27VYMTZywGbW+i8qGc4rhK88QazMNG6AhZj7FIR4BqMrPmz1QDqxUq3qM26mOocg==",
       "requires": {
-        "patch-book": "1.0.16"
+        "patch-book": "^1.0.16"
       }
     },
     "patchbay-gatherings": {
@@ -5012,15 +4912,15 @@
       "resolved": "https://registry.npmjs.org/patchbay-gatherings/-/patchbay-gatherings-2.0.2.tgz",
       "integrity": "sha512-+SdurkgSQl07N52pGbwGjUPdyLXtmm8EfwJfSSEUgUZjzf/VThvkplWSzpEw5vmotyLWZHdRG7Z6z1RDXIVsYw==",
       "requires": {
-        "bulk-require": "1.0.1",
-        "depject": "4.1.1",
-        "depnest": "1.3.0",
-        "libnested": "1.3.2",
-        "mutant": "3.22.1",
-        "patch-gatherings": "2.4.7",
-        "pull-scroll": "1.0.9",
-        "pull-stream": "3.6.8",
-        "read-directory": "2.1.1"
+        "bulk-require": "^1.0.0",
+        "depject": "^4.1.0",
+        "depnest": "^1.3.0",
+        "libnested": "^1.2.1",
+        "mutant": "^3.19.0",
+        "patch-gatherings": "^2.4.6",
+        "pull-scroll": "^1.0.8",
+        "pull-stream": "^3.5.0",
+        "read-directory": "^2.0.0"
       }
     },
     "patchbay-poll": {
@@ -5028,39 +4928,34 @@
       "resolved": "https://registry.npmjs.org/patchbay-poll/-/patchbay-poll-1.0.5.tgz",
       "integrity": "sha512-1yMoX4YnKzDbXlj3G3QjnEH8rNppYGzi4m8/Rm+HakAUX6OSppIrEjRIDwzhEKNov+uYViPJml/U1+zGebbIDw==",
       "requires": {
-        "cross-script": "1.0.5",
-        "depnest": "1.3.0",
-        "flatpickr": "4.5.0",
-        "libnested": "1.3.2",
-        "lodash": "4.17.10",
-        "mutant": "3.22.1",
+        "cross-script": "^1.0.5",
+        "depnest": "^1.3.0",
+        "flatpickr": "^4.4.4",
+        "libnested": "^1.2.1",
+        "lodash": "^4.17.10",
+        "mutant": "^3.22.1",
         "mutant-scroll": "0.0.5",
-        "pull-next-query": "1.0.0",
-        "pull-stream": "3.6.8",
-        "read-directory": "3.0.0",
-        "require-style": "1.0.1",
-        "scuttle-poll": "1.2.0",
-        "ssb-poll-schema": "1.6.1"
+        "pull-next-query": "^1.0.0",
+        "pull-stream": "^3.6.2",
+        "read-directory": "^3.0.0",
+        "require-style": "^1.0.1",
+        "scuttle-poll": "^1.2.0",
+        "ssb-poll-schema": "^1.3.3"
       },
       "dependencies": {
         "flatpickr": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.5.0.tgz",
-          "integrity": "sha512-7AfaM2BVyQmFW4uBpzgoNeRUr6EZlvEh4Pnj298rEsHBq8LIZnPgRaesLORir7dATETUvoLkhrfXZdmNssma+A=="
-        },
-        "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+          "version": "4.5.1",
+          "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.5.1.tgz",
+          "integrity": "sha512-dsLTFmRg6mlqYfJ35A7gLlbq+8fOqRty3cWncl6rwU4pMe//i0WKxKLVyBbSYAZry93Lg+yqsOph9haltcxCqQ=="
         },
         "mutant-scroll": {
           "version": "0.0.5",
           "resolved": "https://registry.npmjs.org/mutant-scroll/-/mutant-scroll-0.0.5.tgz",
           "integrity": "sha512-sHAK328p8NYD1HU/0+b/NLbO1x1clpafMKzti4pXZOjQGQ2UnblAFi7TEd5+YZeEz3KZNuFf3tsnw9qG4OHxGQ==",
           "requires": {
-            "mutant": "3.22.1",
+            "mutant": "^3.22.1",
             "pull-pause": "0.0.1",
-            "pull-stream": "3.6.8"
+            "pull-stream": "^3.6.1"
           }
         },
         "pull-pause": {
@@ -5073,11 +4968,11 @@
           "resolved": "https://registry.npmjs.org/read-directory/-/read-directory-3.0.0.tgz",
           "integrity": "sha512-D9aGTSoUm2AxxEX8brBkGOB7GZ7/Opv5AuQCz0VRsccPV2WwsEoRpN5bRPGi/XhRF00SRYhpgwI14Uk7QsPbEA==",
           "requires": {
-            "defaults": "1.0.3",
-            "each-async": "1.1.1",
-            "glob": "7.1.2",
-            "static-module": "1.5.0",
-            "through2": "2.0.3"
+            "defaults": "^1.0.3",
+            "each-async": "^1.1.1",
+            "glob": "^7.1.2",
+            "static-module": "^1.3.2",
+            "through2": "^2.0.3"
           }
         },
         "through2": {
@@ -5085,8 +4980,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "requires": {
-            "readable-stream": "2.3.3",
-            "xtend": "4.0.1"
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -5096,49 +4991,38 @@
       "resolved": "https://registry.npmjs.org/patchcore/-/patchcore-1.28.0.tgz",
       "integrity": "sha512-to/RzFGccTDVypemXMEc7B8hjvLYvCIw6ifL7vp+nXrQzauwwSTZwqWHzNstHmIuAV165wXEjGUWqVTMsgf7CQ==",
       "requires": {
-        "bulk-require": "1.0.1",
-        "bulkify": "1.4.2",
-        "color-hash": "1.0.3",
-        "depnest": "1.3.0",
-        "emoji-named-characters": "1.0.2",
-        "es2040": "1.2.6",
-        "flat": "4.1.0",
-        "hashlru": "2.2.0",
-        "html-escape": "2.0.0",
+        "bulk-require": "^1.0.0",
+        "bulkify": "^1.4.2",
+        "color-hash": "^1.0.3",
+        "depnest": "^1.0.2",
+        "emoji-named-characters": "^1.0.2",
+        "es2040": "^1.2.4",
+        "flat": "^4.0.0",
+        "hashlru": "^2.2.0",
+        "html-escape": "^2.0.0",
         "human-time": "0.0.1",
-        "mutant": "3.22.1",
-        "mutant-pull-reduce": "1.1.0",
-        "piexifjs": "1.0.4",
-        "pull-abortable": "4.1.1",
-        "pull-box-stream": "1.0.13",
-        "pull-cat": "1.1.11",
-        "pull-defer": "0.2.2",
+        "mutant": "^3.21.2",
+        "mutant-pull-reduce": "^1.1.0",
+        "piexifjs": "^1.0.4",
+        "pull-abortable": "^4.1.0",
+        "pull-box-stream": "~1.0.13",
+        "pull-cat": "^1.1.11",
+        "pull-defer": "~0.2.2",
         "pull-reconnect": "0.0.3",
-        "pull-stream": "3.6.8",
-        "scuttle-blog": "1.0.1",
-        "simple-mime": "0.1.0",
-        "sorted-array-functions": "1.2.0",
-        "split-buffer": "1.0.0",
-        "ssb-client": "4.5.7",
-        "ssb-config": "2.2.0",
-        "ssb-feed": "2.3.0",
-        "ssb-friends": "2.4.0",
-        "ssb-keys": "7.0.16",
-        "ssb-markdown": "3.6.0",
-        "ssb-ref": "2.11.1",
-        "ssb-sort": "1.1.0",
-        "xtend": "4.0.1"
-      },
-      "dependencies": {
-        "ssb-ref": {
-          "version": "2.11.1",
-          "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.11.1.tgz",
-          "integrity": "sha512-K3L9hJ1v0HrH8abtEKiBkdeabHVaws+CS81mZqUfhR84i0dlYhiIIDwqeLxUj/1mLcsZPF3gMKPsFCUr7UAdMA==",
-          "requires": {
-            "ip": "1.1.5",
-            "is-valid-domain": "0.0.5"
-          }
-        }
+        "pull-stream": "^3.5.0",
+        "scuttle-blog": "^1.0.0",
+        "simple-mime": "^0.1.0",
+        "sorted-array-functions": "^1.0.0",
+        "split-buffer": "^1.0.0",
+        "ssb-client": "^4.5.2",
+        "ssb-config": "^2.2.0",
+        "ssb-feed": "^2.3.0",
+        "ssb-friends": "^2.2.3",
+        "ssb-keys": "^7.0.9",
+        "ssb-markdown": "^3.6.0",
+        "ssb-ref": "^2.11.0",
+        "ssb-sort": "^1.0.0",
+        "xtend": "^4.0.1"
       }
     },
     "path-exists": {
@@ -5147,7 +5031,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "2.0.1"
+        "pinkie-promise": "^2.0.0"
       }
     },
     "path-is-absolute": {
@@ -5172,9 +5056,9 @@
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "pend": {
@@ -5209,7 +5093,7 @@
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pkg-config": {
@@ -5218,9 +5102,9 @@
       "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
       "dev": true,
       "requires": {
-        "debug-log": "1.0.1",
-        "find-root": "1.1.0",
-        "xtend": "4.0.1"
+        "debug-log": "^1.0.0",
+        "find-root": "^1.0.0",
+        "xtend": "^4.0.1"
       }
     },
     "plur": {
@@ -5228,7 +5112,7 @@
       "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
       "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
       "requires": {
-        "irregular-plurals": "1.4.0"
+        "irregular-plurals": "^1.0.0"
       }
     },
     "pluralize": {
@@ -5242,9 +5126,9 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.1.tgz",
       "integrity": "sha1-AA29H47vIXqjaLmiEsX8QLKo8/I=",
       "requires": {
-        "chalk": "1.1.3",
-        "source-map": "0.5.7",
-        "supports-color": "3.2.3"
+        "chalk": "^1.1.3",
+        "source-map": "^0.5.6",
+        "supports-color": "^3.2.3"
       },
       "dependencies": {
         "source-map": {
@@ -5257,7 +5141,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -5267,7 +5151,7 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
       "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
       "requires": {
-        "postcss": "6.0.1"
+        "postcss": "^6.0.1"
       }
     },
     "postcss-modules-local-by-default": {
@@ -5275,8 +5159,8 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
       "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
       "requires": {
-        "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.1"
+        "css-selector-tokenizer": "^0.7.0",
+        "postcss": "^6.0.1"
       }
     },
     "postcss-modules-scope": {
@@ -5284,8 +5168,8 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
       "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
       "requires": {
-        "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.1"
+        "css-selector-tokenizer": "^0.7.0",
+        "postcss": "^6.0.1"
       }
     },
     "postcss-modules-values": {
@@ -5293,8 +5177,46 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
       "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
       "requires": {
-        "icss-replace-symbols": "1.1.0",
-        "postcss": "6.0.1"
+        "icss-replace-symbols": "^1.1.0",
+        "postcss": "^6.0.1"
+      }
+    },
+    "prebuild-install": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-4.0.0.tgz",
+      "integrity": "sha512-7tayxeYboJX0RbVzdnKyGl2vhQRWr6qfClEXDhOkXjuaOKCw2q8aiuFhONRYVsG/czia7KhpykIlI2S2VaPunA==",
+      "requires": {
+        "detect-libc": "^1.0.3",
+        "expand-template": "^1.0.2",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "node-abi": "^2.2.0",
+        "noop-logger": "^0.1.1",
+        "npmlog": "^4.0.1",
+        "os-homedir": "^1.0.1",
+        "pump": "^2.0.1",
+        "rc": "^1.1.6",
+        "simple-get": "^2.7.0",
+        "tar-fs": "^1.13.0",
+        "tunnel-agent": "^0.6.0",
+        "which-pm-runs": "^1.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "pump": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
       }
     },
     "prelude-ls": {
@@ -5314,8 +5236,8 @@
       "integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1",
-        "meow": "3.7.0"
+        "get-stdin": "^4.0.1",
+        "meow": "^3.1.0"
       }
     },
     "private": {
@@ -5328,7 +5250,7 @@
       "resolved": "https://registry.npmjs.org/private-box/-/private-box-0.2.1.tgz",
       "integrity": "sha1-HfBhr8pbMDnH/qrdDa8PVvB+PsA=",
       "requires": {
-        "chloride": "2.2.8"
+        "chloride": "^2.2.1"
       }
     },
     "process-nextick-args": {
@@ -5348,8 +5270,8 @@
       "integrity": "sha1-LNPP6jO6OonJwSHsM0er6asSX3c=",
       "dev": true,
       "requires": {
-        "speedometer": "0.1.4",
-        "through2": "0.2.3"
+        "speedometer": "~0.1.2",
+        "through2": "~0.2.3"
       },
       "dependencies": {
         "isarray": {
@@ -5370,10 +5292,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -5388,8 +5310,8 @@
           "integrity": "sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=",
           "dev": true,
           "requires": {
-            "readable-stream": "1.1.14",
-            "xtend": "2.1.2"
+            "readable-stream": "~1.1.9",
+            "xtend": "~2.1.1"
           }
         },
         "xtend": {
@@ -5398,15 +5320,15 @@
           "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
           "dev": true,
           "requires": {
-            "object-keys": "0.4.0"
+            "object-keys": "~0.4.0"
           }
         }
       }
     },
     "prr": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-      "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -5433,7 +5355,7 @@
       "resolved": "https://registry.npmjs.org/pull-async-filter/-/pull-async-filter-1.0.0.tgz",
       "integrity": "sha1-68NhfZ3iRjkIyJ/QFnHHJ1ZNaDE=",
       "requires": {
-        "pull-stream": "2.28.4"
+        "pull-stream": "^2.26.0"
       },
       "dependencies": {
         "pull-stream": {
@@ -5441,7 +5363,7 @@
           "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-2.28.4.tgz",
           "integrity": "sha1-fql0E8FhnCC8O9+eEOkTR7AyU+Q=",
           "requires": {
-            "pull-core": "1.1.0"
+            "pull-core": "~1.1.0"
           }
         }
       }
@@ -5456,12 +5378,12 @@
       "resolved": "https://registry.npmjs.org/pull-box-stream/-/pull-box-stream-1.0.13.tgz",
       "integrity": "sha1-w+JAOY6rP1lRsu0QeMWYi/egork=",
       "requires": {
-        "chloride": "2.2.8",
-        "increment-buffer": "1.0.1",
-        "pull-reader": "1.2.9",
-        "pull-stream": "3.6.8",
-        "pull-through": "1.0.18",
-        "split-buffer": "1.0.0"
+        "chloride": "^2.2.7",
+        "increment-buffer": "~1.0.0",
+        "pull-reader": "^1.2.5",
+        "pull-stream": "^3.2.3",
+        "pull-through": "^1.0.18",
+        "split-buffer": "~1.0.0"
       }
     },
     "pull-buffered": {
@@ -5469,7 +5391,7 @@
       "resolved": "https://registry.npmjs.org/pull-buffered/-/pull-buffered-0.3.4.tgz",
       "integrity": "sha512-rs5MtSaB1LQfXyer2uderwS4ypsTdmh9VC4wZC0WZsIBKqHiy7tFqNZ0QP1ln544N+yQGXEBRbwYn59iO6Ub9w==",
       "requires": {
-        "pull-looper": "1.0.0"
+        "pull-looper": "^1.0.0"
       }
     },
     "pull-cache": {
@@ -5492,17 +5414,27 @@
       "resolved": "https://registry.npmjs.org/pull-core/-/pull-core-1.1.0.tgz",
       "integrity": "sha1-PYEn1trBR1cFyYAJYfWdZsgEbIo="
     },
+    "pull-cursor": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pull-cursor/-/pull-cursor-3.0.0.tgz",
+      "integrity": "sha512-95lZVSF2eSEdOmUtlOBaD9p5YOvlYeCr5FBv2ySqcj/4rpaXI6d8OH+zPHHjKAf58R8QXJRZuyfHkcCX8TZbAg==",
+      "requires": {
+        "looper": "^4.0.0",
+        "ltgt": "^2.2.0",
+        "pull-stream": "^3.6.0"
+      }
+    },
     "pull-defer": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.2.tgz",
       "integrity": "sha1-CIew/7MK8ypW2+z6csFnInHwexM="
     },
     "pull-file": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pull-file/-/pull-file-1.0.0.tgz",
-      "integrity": "sha1-WgywNteO4Q4+C0KT389u/6EDYxg=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pull-file/-/pull-file-1.1.0.tgz",
+      "integrity": "sha1-HdmHYF1jV6DSPB5Lgm95FaIVEpw=",
       "requires": {
-        "pull-utf8-decoder": "1.0.2"
+        "pull-utf8-decoder": "^1.0.2"
       }
     },
     "pull-flatmap": {
@@ -5515,10 +5447,10 @@
       "resolved": "https://registry.npmjs.org/pull-fs/-/pull-fs-1.1.6.tgz",
       "integrity": "sha1-8YT2p3KLtNlWQTdr6tafb2bfR80=",
       "requires": {
-        "pull-file": "0.5.0",
-        "pull-stream": "3.6.8",
-        "pull-traverse": "1.0.3",
-        "pull-write-file": "0.2.4"
+        "pull-file": "^0.5.0",
+        "pull-stream": "^3.3.0",
+        "pull-traverse": "^1.0.3",
+        "pull-write-file": "^0.2.1"
       },
       "dependencies": {
         "pull-file": {
@@ -5526,7 +5458,7 @@
           "resolved": "https://registry.npmjs.org/pull-file/-/pull-file-0.5.0.tgz",
           "integrity": "sha1-s8pAUwbggvnUUoKIkzutsrZWNls=",
           "requires": {
-            "pull-utf8-decoder": "1.0.2"
+            "pull-utf8-decoder": "^1.0.2"
           }
         }
       }
@@ -5536,13 +5468,13 @@
       "resolved": "https://registry.npmjs.org/pull-git-pack/-/pull-git-pack-1.0.2.tgz",
       "integrity": "sha512-WZzAAs9ap+QBHliP3E7sCn9kRfMNbdtFVOU0wRRtbY8x6+SUGeCpIkeYUcl9K/KgkL+2XZeyKXzPZ688IyfMbQ==",
       "requires": {
-        "pako": "1.0.6",
-        "pull-buffered": "0.3.4",
-        "pull-cat": "1.1.11",
-        "pull-git-packidx-parser": "1.0.0",
-        "pull-looper": "1.0.0",
-        "pull-stream": "3.6.8",
-        "stream-to-pull-stream": "1.7.2"
+        "pako": "^1.0.3",
+        "pull-buffered": "^0.3.3",
+        "pull-cat": "^1.1.8",
+        "pull-git-packidx-parser": "^1.0.0",
+        "pull-looper": "^1.0.0",
+        "pull-stream": "^3.1.0",
+        "stream-to-pull-stream": "^1.6.6"
       }
     },
     "pull-git-pack-concat": {
@@ -5550,13 +5482,13 @@
       "resolved": "https://registry.npmjs.org/pull-git-pack-concat/-/pull-git-pack-concat-0.2.1.tgz",
       "integrity": "sha1-t8gzTDpJYfxbWVo00dQiTaYILVU=",
       "requires": {
-        "looper": "3.0.0",
-        "multicb": "1.2.2",
-        "pull-block-filter": "1.0.0",
-        "pull-cat": "1.1.11",
-        "pull-git-packidx-parser": "1.0.0",
-        "pull-skip-footer": "0.1.0",
-        "pull-stream": "3.6.8"
+        "looper": "^3.0.0",
+        "multicb": "^1.2.1",
+        "pull-block-filter": "^1.0.0",
+        "pull-cat": "^1.1.8",
+        "pull-git-packidx-parser": "^1.0.0",
+        "pull-skip-footer": "^0.1.0",
+        "pull-stream": "^3.1.0"
       },
       "dependencies": {
         "looper": {
@@ -5571,7 +5503,7 @@
       "resolved": "https://registry.npmjs.org/pull-git-packidx-parser/-/pull-git-packidx-parser-1.0.0.tgz",
       "integrity": "sha1-LYvwr+SCSJfuA4QL/k9ahq/syiE=",
       "requires": {
-        "pull-stream": "3.6.8"
+        "pull-stream": "^3.4.5"
       }
     },
     "pull-git-repo": {
@@ -5579,27 +5511,27 @@
       "resolved": "https://registry.npmjs.org/pull-git-repo/-/pull-git-repo-1.2.1.tgz",
       "integrity": "sha512-nHOicXiFryxuO9J+EhYY0cFC4n4mvsDabj6ts6BYgRbWAbp/gQUa+Hzfy05uey+HLz7XaR7N8XC+xGBgsYCmsg==",
       "requires": {
-        "asyncmemo": "1.0.0",
-        "git-packidx-parser": "1.0.0",
-        "multicb": "1.2.2",
-        "pull-buffered": "0.3.4",
-        "pull-cache": "0.0.0",
-        "pull-cat": "1.1.11",
-        "pull-git-pack": "1.0.2",
-        "pull-hash": "1.0.0",
-        "pull-kvdiff": "0.0.0",
-        "pull-paramap": "1.2.2",
-        "semver": "5.4.1",
-        "stream-to-pull-stream": "1.7.2"
+        "asyncmemo": "^1.0.0",
+        "git-packidx-parser": "^1.0.0",
+        "multicb": "^1.2.1",
+        "pull-buffered": "^0.3.3",
+        "pull-cache": "^0.0.0",
+        "pull-cat": "^1.1.11",
+        "pull-git-pack": "^1.0.1",
+        "pull-hash": "^1.0.0",
+        "pull-kvdiff": "^0.0.0",
+        "pull-paramap": "^1.2.1",
+        "semver": "^5.3.0",
+        "stream-to-pull-stream": "^1.7.2"
       }
     },
     "pull-glob": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/pull-glob/-/pull-glob-1.0.6.tgz",
-      "integrity": "sha1-3qWsWUjuFZeNqyTXdyApJ/aK6KY=",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/pull-glob/-/pull-glob-1.0.7.tgz",
+      "integrity": "sha1-7vkV3eZEvdvqjdLgEG1USqy81cI=",
       "requires": {
-        "pull-fs": "1.1.6",
-        "pull-stream": "3.6.8"
+        "pull-fs": "~1.1.6",
+        "pull-stream": "^3.3.0"
       }
     },
     "pull-goodbye": {
@@ -5607,7 +5539,7 @@
       "resolved": "https://registry.npmjs.org/pull-goodbye/-/pull-goodbye-0.0.2.tgz",
       "integrity": "sha1-jYNX21XiKnEN//DxaoyQtF7+QXE=",
       "requires": {
-        "pull-stream": "3.5.0"
+        "pull-stream": "~3.5.0"
       },
       "dependencies": {
         "pull-stream": {
@@ -5622,10 +5554,10 @@
       "resolved": "https://registry.npmjs.org/pull-handshake/-/pull-handshake-1.1.4.tgz",
       "integrity": "sha1-YACg/QGIhM39c3JU+Mxgqypjd5E=",
       "requires": {
-        "pull-cat": "1.1.11",
-        "pull-pair": "1.1.0",
-        "pull-pushable": "2.1.1",
-        "pull-reader": "1.2.9"
+        "pull-cat": "^1.1.9",
+        "pull-pair": "~1.1.0",
+        "pull-pushable": "^2.0.0",
+        "pull-reader": "^1.2.3"
       }
     },
     "pull-hash": {
@@ -5638,8 +5570,8 @@
       "resolved": "https://registry.npmjs.org/pull-inactivity/-/pull-inactivity-2.1.2.tgz",
       "integrity": "sha1-N6PW67+sKSzUNfXkgeUHTIwfrXU=",
       "requires": {
-        "pull-abortable": "4.0.0",
-        "pull-stream": "3.6.8"
+        "pull-abortable": "~4.0.0",
+        "pull-stream": "^3.4.5"
       },
       "dependencies": {
         "pull-abortable": {
@@ -5659,21 +5591,21 @@
       "resolved": "https://registry.npmjs.org/pull-kvdiff/-/pull-kvdiff-0.0.0.tgz",
       "integrity": "sha1-m2Yn0OMy2YKI5H1HFgIWH0H/E1M=",
       "requires": {
-        "multicb": "1.2.2"
+        "multicb": "^1.2.1"
       }
     },
     "pull-level": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.3.tgz",
-      "integrity": "sha1-lQBjXiV5Rdb+7eGF9deiR3NFWxc=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.4.tgz",
+      "integrity": "sha512-fW6pljDeUThpq5KXwKbRG3X7Ogk3vc75d5OQU/TvXXui65ykm+Bn+fiktg+MOx2jJ85cd+sheufPL+rw9QSVZg==",
       "requires": {
-        "level-post": "1.0.5",
-        "pull-cat": "1.1.11",
-        "pull-live": "1.0.1",
-        "pull-pushable": "2.1.1",
-        "pull-stream": "3.6.8",
-        "pull-window": "2.1.4",
-        "stream-to-pull-stream": "1.7.2"
+        "level-post": "^1.0.7",
+        "pull-cat": "^1.1.9",
+        "pull-live": "^1.0.1",
+        "pull-pushable": "^2.0.0",
+        "pull-stream": "^3.4.0",
+        "pull-window": "^2.1.4",
+        "stream-to-pull-stream": "^1.7.1"
       }
     },
     "pull-live": {
@@ -5681,8 +5613,8 @@
       "resolved": "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz",
       "integrity": "sha1-pOzuAeMwFV6RJLu89HYfIbOPUfU=",
       "requires": {
-        "pull-cat": "1.1.11",
-        "pull-stream": "3.6.8"
+        "pull-cat": "^1.1.9",
+        "pull-stream": "^3.4.0"
       }
     },
     "pull-looper": {
@@ -5690,7 +5622,7 @@
       "resolved": "https://registry.npmjs.org/pull-looper/-/pull-looper-1.0.0.tgz",
       "integrity": "sha512-djlD60A6NGe5goLdP5pgbqzMEiWmk1bInuAzBp0QOH4vDrVwh05YDz6UP8+pOXveKEk8wHVP+rB2jBrK31QMPA==",
       "requires": {
-        "looper": "4.0.0"
+        "looper": "^4.0.0"
       }
     },
     "pull-many": {
@@ -5698,7 +5630,7 @@
       "resolved": "https://registry.npmjs.org/pull-many/-/pull-many-1.0.8.tgz",
       "integrity": "sha1-Pa3ZttFWxUVyG9qNAAPdjqoGKT4=",
       "requires": {
-        "pull-stream": "3.6.8"
+        "pull-stream": "^3.4.5"
       }
     },
     "pull-merge": {
@@ -5716,18 +5648,11 @@
       "resolved": "https://registry.npmjs.org/pull-next-query/-/pull-next-query-1.0.0.tgz",
       "integrity": "sha512-pZuaV0A6SH5IQmCNNBKB2WSpHfzgj/lNeprLvCMVRV2Wh4zidtBvjgJrThRLOYxdZilL4z01T3pri0zroqKJcg==",
       "requires": {
-        "lodash.get": "4.4.2",
-        "lodash.merge": "4.6.1",
-        "lodash.set": "4.3.2",
-        "pull-next": "1.0.1",
-        "pull-stream": "3.6.8"
-      },
-      "dependencies": {
-        "lodash.merge": {
-          "version": "4.6.1",
-          "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-          "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
-        }
+        "lodash.get": "^4.4.2",
+        "lodash.merge": "^4.6.1",
+        "lodash.set": "^4.3.2",
+        "pull-next": "^1.0.1",
+        "pull-stream": "^3.6.8"
       }
     },
     "pull-notify": {
@@ -5735,7 +5660,7 @@
       "resolved": "https://registry.npmjs.org/pull-notify/-/pull-notify-0.1.1.tgz",
       "integrity": "sha1-b4b/ldJwuJw+vyVbYDG3Ay3JnMo=",
       "requires": {
-        "pull-pushable": "2.1.1"
+        "pull-pushable": "^2.0.0"
       }
     },
     "pull-pair": {
@@ -5748,7 +5673,7 @@
       "resolved": "https://registry.npmjs.org/pull-paramap/-/pull-paramap-1.2.2.tgz",
       "integrity": "sha1-UaQZPOnI1yFdla2tReK824STsjo=",
       "requires": {
-        "looper": "4.0.0"
+        "looper": "^4.0.0"
       }
     },
     "pull-pause": {
@@ -5761,35 +5686,35 @@
       "resolved": "https://registry.npmjs.org/pull-ping/-/pull-ping-2.0.2.tgz",
       "integrity": "sha1-e8SjQBZ9rYj2gqGWxjSFc1x6CJQ=",
       "requires": {
-        "pull-pushable": "2.1.1",
-        "pull-stream": "3.6.8",
-        "statistics": "3.3.0"
+        "pull-pushable": "^2.0.0",
+        "pull-stream": "^3.4.5",
+        "statistics": "^3.3.0"
       }
     },
     "pull-pushable": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.1.1.tgz",
-      "integrity": "sha1-hmZqu+P1QC8ffq0D7v1pt4Xspbg="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.2.0.tgz",
+      "integrity": "sha1-Xy867UethpGfAbEqLpnW8b13ZYE="
     },
     "pull-rate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pull-rate/-/pull-rate-1.0.2.tgz",
       "integrity": "sha1-F7IxrV81n2dYJmcBcrDlkMiWTo0=",
       "requires": {
-        "pull-stream": "3.6.8"
+        "pull-stream": "^3.6.0"
       }
     },
     "pull-reader": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/pull-reader/-/pull-reader-1.2.9.tgz",
-      "integrity": "sha1-0umtALz7VOYqpm1Cwtu8tetoQ7A="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pull-reader/-/pull-reader-1.3.1.tgz",
+      "integrity": "sha512-CBkejkE5nX50SiSEzu0Qoz4POTJMS/mw8G6aj3h3M/RJoKgggLxyF0IyTZ0mmpXFlXRcLmLmIEW4xeYn7AeDYw=="
     },
     "pull-reconnect": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/pull-reconnect/-/pull-reconnect-0.0.3.tgz",
       "integrity": "sha1-U9zpzS8rmyEOiIleGfL/xnYh3J4=",
       "requires": {
-        "pull-defer": "0.2.2"
+        "pull-defer": "^0.2.2"
       }
     },
     "pull-scroll": {
@@ -5799,7 +5724,7 @@
       "requires": {
         "obv": "0.0.1",
         "pull-pause": "0.0.0",
-        "pull-stream": "3.6.8"
+        "pull-stream": "^3.0.1"
       }
     },
     "pull-sink-through": {
@@ -5817,8 +5742,8 @@
       "resolved": "https://registry.npmjs.org/pull-sort/-/pull-sort-1.0.1.tgz",
       "integrity": "sha1-qKsMcMhvRTQ8mszJOfxCdprT3G0=",
       "requires": {
-        "pull-defer": "0.2.2",
-        "pull-stream": "3.6.8"
+        "pull-defer": "^0.2.2",
+        "pull-stream": "^3.6.0"
       }
     },
     "pull-stream": {
@@ -5841,7 +5766,7 @@
       "resolved": "https://registry.npmjs.org/pull-through/-/pull-through-1.0.18.tgz",
       "integrity": "sha1-jdYjFCY+Wc9Qlur7sSeitu8xBzU=",
       "requires": {
-        "looper": "3.0.0"
+        "looper": "~3.0.0"
       },
       "dependencies": {
         "looper": {
@@ -5866,7 +5791,7 @@
       "resolved": "https://registry.npmjs.org/pull-window/-/pull-window-2.1.4.tgz",
       "integrity": "sha1-/DuG/uvRkgx64pdpHiP3BfiFUvA=",
       "requires": {
-        "looper": "2.0.0"
+        "looper": "^2.0.0"
       },
       "dependencies": {
         "looper": {
@@ -5881,9 +5806,9 @@
       "resolved": "https://registry.npmjs.org/pull-write/-/pull-write-1.1.4.tgz",
       "integrity": "sha1-3d6jFJO0j2douEooHQHrO1Mf4Lg=",
       "requires": {
-        "looper": "4.0.0",
-        "pull-cat": "1.1.11",
-        "pull-stream": "3.6.8"
+        "looper": "^4.0.0",
+        "pull-cat": "^1.1.11",
+        "pull-stream": "^3.4.5"
       }
     },
     "pull-write-file": {
@@ -5892,13 +5817,13 @@
       "integrity": "sha1-Q3NErrIYn2XmeO0a838PdgpUU+8="
     },
     "pull-ws": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/pull-ws/-/pull-ws-3.3.0.tgz",
-      "integrity": "sha1-4cQ+9AMyFn3YEg71nt9+iSvqSq4=",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/pull-ws/-/pull-ws-3.3.1.tgz",
+      "integrity": "sha512-kJodbLQT+oKjcRIQO+vQNw6xWBuEo7Kxp51VMOvb6cvPvHYA+aNLzm+NmkB/5dZwbuTRYGMal9QPvH52tzM1ZA==",
       "requires": {
-        "relative-url": "1.0.2",
-        "safe-buffer": "5.1.2",
-        "ws": "1.1.5"
+        "relative-url": "^1.0.2",
+        "safe-buffer": "^5.1.1",
+        "ws": "^1.1.0"
       }
     },
     "pump": {
@@ -5906,8 +5831,8 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
       "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
       "requires": {
-        "end-of-stream": "1.4.0",
-        "once": "1.4.0"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "punycode": {
@@ -5926,7 +5851,7 @@
       "resolved": "https://registry.npmjs.org/push-stream-to-pull-stream/-/push-stream-to-pull-stream-1.0.1.tgz",
       "integrity": "sha512-gZe8pNlDFIi+0Ir2TeEFTpbrztLYVHvJgAjxOg8NFOcrisb9MKqIMSx+fmWMR6H/9PTZ2CwXubZlQWACKZ28Zw==",
       "requires": {
-        "pull-looper": "1.0.0"
+        "pull-looper": "^1.0.0"
       }
     },
     "qs": {
@@ -5941,7 +5866,7 @@
       "integrity": "sha1-zeKelMQJsW4Z3HCYuJtmWPlyHTs=",
       "requires": {
         "minimist": "0.0.8",
-        "through2": "0.4.2"
+        "through2": "~0.4.1"
       }
     },
     "ramda": {
@@ -5950,39 +5875,24 @@
       "integrity": "sha1-w7d1UZfzW43DUCIoJixMkd22uFc="
     },
     "randomatic": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
+      "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
       },
       "dependencies": {
         "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
         },
         "kind-of": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "requires": {
-            "is-buffer": "1.1.6"
-          }
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },
@@ -5991,10 +5901,10 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
       "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
       "requires": {
-        "deep-extend": "0.4.2",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
+        "deep-extend": "~0.4.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       },
       "dependencies": {
         "minimist": {
@@ -6009,11 +5919,11 @@
       "resolved": "https://registry.npmjs.org/read-directory/-/read-directory-2.1.1.tgz",
       "integrity": "sha512-EcddB5NmgJzwmHmf7P7ovcydggESS+bhRGFivxaxWsrpDerBl9O1mEFpi5O6pZ+5g/eI8P/ghAWRyz7VtI2D4Q==",
       "requires": {
-        "defaults": "1.0.3",
-        "each-async": "1.1.1",
-        "glob": "7.1.2",
-        "static-module": "1.5.0",
-        "through2": "2.0.3"
+        "defaults": "^1.0.3",
+        "each-async": "^1.1.1",
+        "glob": "^7.1.2",
+        "static-module": "^1.3.2",
+        "through2": "^2.0.3"
       },
       "dependencies": {
         "through2": {
@@ -6021,8 +5931,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "requires": {
-            "readable-stream": "2.3.3",
-            "xtend": "4.0.1"
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -6033,9 +5943,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "1.1.0"
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
       }
     },
     "read-pkg-up": {
@@ -6044,8 +5954,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
       }
     },
     "readable-stream": {
@@ -6053,13 +5963,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.2",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.0.3",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readdirp": {
@@ -6067,10 +5977,10 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.3",
-        "set-immediate-shim": "1.0.1"
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "readable-stream": "^2.0.2",
+        "set-immediate-shim": "^1.0.1"
       }
     },
     "readline2": {
@@ -6079,8 +5989,8 @@
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
         "mute-stream": "0.0.5"
       }
     },
@@ -6090,7 +6000,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "1.5.0"
+        "resolve": "^1.1.6"
       }
     },
     "redent": {
@@ -6099,8 +6009,8 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
       }
     },
     "regenerate": {
@@ -6109,16 +6019,16 @@
       "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
     },
     "regenerator-runtime": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "regex-cache": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "requires": {
-        "is-equal-shallow": "0.1.3"
+        "is-equal-shallow": "^0.1.3"
       }
     },
     "regexpu-core": {
@@ -6126,9 +6036,9 @@
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
       "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
       "requires": {
-        "regenerate": "1.4.0",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
       }
     },
     "regjsgen": {
@@ -6141,7 +6051,7 @@
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "requires": {
-        "jsesc": "0.5.0"
+        "jsesc": "~0.5.0"
       },
       "dependencies": {
         "jsesc": {
@@ -6161,37 +6071,37 @@
       "resolved": "https://registry.npmjs.org/remark/-/remark-3.2.3.tgz",
       "integrity": "sha1-gCo4w6qYyeHj6gFe66IR0ny2Xh8=",
       "requires": {
-        "camelcase": "2.1.1",
-        "ccount": "1.0.2",
-        "chalk": "1.1.3",
-        "chokidar": "1.7.0",
-        "collapse-white-space": "1.0.3",
-        "commander": "2.12.1",
-        "concat-stream": "1.6.0",
-        "debug": "2.6.9",
-        "elegant-spinner": "1.0.1",
+        "camelcase": "^2.0.0",
+        "ccount": "^1.0.0",
+        "chalk": "^1.0.0",
+        "chokidar": "^1.0.5",
+        "collapse-white-space": "^1.0.0",
+        "commander": "^2.0.0",
+        "concat-stream": "^1.0.0",
+        "debug": "^2.0.0",
+        "elegant-spinner": "^1.0.0",
         "extend.js": "0.0.2",
-        "glob": "6.0.4",
-        "globby": "4.1.0",
-        "he": "0.5.0",
-        "log-update": "1.0.2",
-        "longest-streak": "1.0.0",
-        "markdown-table": "0.4.0",
-        "minimatch": "3.0.4",
-        "npm-prefix": "1.2.0",
-        "parse-entities": "1.1.1",
-        "repeat-string": "1.6.1",
-        "stringify-entities": "1.3.1",
-        "to-vfile": "1.0.0",
-        "trim": "0.0.1",
-        "trim-trailing-lines": "1.1.0",
-        "unified": "2.1.4",
-        "user-home": "2.0.0",
-        "vfile": "1.4.0",
-        "vfile-find-down": "1.0.0",
-        "vfile-find-up": "1.0.0",
-        "vfile-reporter": "1.5.0",
-        "ware": "1.3.0"
+        "glob": "^6.0.1",
+        "globby": "^4.0.0",
+        "he": "^0.5.0",
+        "log-update": "^1.0.1",
+        "longest-streak": "^1.0.0",
+        "markdown-table": "^0.4.0",
+        "minimatch": "^3.0.0",
+        "npm-prefix": "^1.0.1",
+        "parse-entities": "^1.0.0",
+        "repeat-string": "^1.5.0",
+        "stringify-entities": "^1.0.0",
+        "to-vfile": "^1.0.0",
+        "trim": "^0.0.1",
+        "trim-trailing-lines": "^1.0.0",
+        "unified": "^2.0.0",
+        "user-home": "^2.0.0",
+        "vfile": "^1.1.0",
+        "vfile-find-down": "^1.0.0",
+        "vfile-find-up": "^1.0.0",
+        "vfile-reporter": "^1.5.0",
+        "ware": "^1.3.0"
       },
       "dependencies": {
         "glob": {
@@ -6199,11 +6109,11 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -6213,13 +6123,13 @@
       "resolved": "https://registry.npmjs.org/remark-html/-/remark-html-2.0.2.tgz",
       "integrity": "sha1-WSo0e909WIH08IDJi1sVL7FAepI=",
       "requires": {
-        "collapse-white-space": "1.0.3",
-        "detab": "1.0.2",
-        "normalize-uri": "1.1.0",
-        "object-assign": "4.1.1",
+        "collapse-white-space": "^1.0.0",
+        "detab": "^1.0.0",
+        "normalize-uri": "^1.0.0",
+        "object-assign": "^4.0.1",
         "trim": "0.0.1",
-        "trim-lines": "1.1.0",
-        "unist-util-visit": "1.2.0"
+        "trim-lines": "^1.0.0",
+        "unist-util-visit": "^1.0.0"
       }
     },
     "remove-trailing-separator": {
@@ -6242,7 +6152,7 @@
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "replacestream": {
@@ -6250,9 +6160,9 @@
       "resolved": "https://registry.npmjs.org/replacestream/-/replacestream-4.0.3.tgz",
       "integrity": "sha512-AC0FiLS352pBBiZhd4VXB1Ab/lh0lEgpP+GGvZqbQh8a5cmXVoTe5EX/YeTFArnp4SRGTHh1qCHu9lGs1qG8sA==",
       "requires": {
-        "escape-string-regexp": "1.0.5",
-        "object-assign": "4.1.1",
-        "readable-stream": "2.3.3"
+        "escape-string-regexp": "^1.0.3",
+        "object-assign": "^4.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "request": {
@@ -6261,26 +6171,26 @@
       "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.7.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.2",
-        "har-validator": "5.0.3",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.19",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.1.2",
-        "tough-cookie": "2.3.4",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.3.2"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       }
     },
     "require-style": {
@@ -6288,18 +6198,18 @@
       "resolved": "https://registry.npmjs.org/require-style/-/require-style-1.0.1.tgz",
       "integrity": "sha512-N4thpS0QXydyIptiuQ611Q2jeboFeJtGFhQWaMzfCDYAMbqlz8eGKxkpwmcH2tuRA3m6tMuqpk3XnrFzrTwSPA==",
       "requires": {
-        "css-url-regex": "1.1.0",
-        "from2-string": "1.1.0",
-        "is-windows": "1.0.1",
-        "pump": "1.0.3",
-        "quote-stream": "1.0.2",
-        "readable-stream": "2.3.3",
-        "replacestream": "4.0.3",
-        "resolve": "1.5.0",
-        "slash": "1.0.0",
-        "static-module": "1.5.0",
-        "style-resolve": "1.0.1",
-        "urify": "2.1.0"
+        "css-url-regex": "^1.1.0",
+        "from2-string": "^1.1.0",
+        "is-windows": "^1.0.1",
+        "pump": "^1.0.2",
+        "quote-stream": "^1.0.2",
+        "readable-stream": "^2.2.10",
+        "replacestream": "^4.0.2",
+        "resolve": "^1.3.3",
+        "slash": "^1.0.0",
+        "static-module": "^1.3.2",
+        "style-resolve": "^1.0.1",
+        "urify": "^2.1.0"
       },
       "dependencies": {
         "minimist": {
@@ -6313,8 +6223,8 @@
           "integrity": "sha1-hJY/jJwmuULhU/7rU6rnRlK34LI=",
           "requires": {
             "buffer-equal": "0.0.1",
-            "minimist": "1.2.0",
-            "through2": "2.0.3"
+            "minimist": "^1.1.3",
+            "through2": "^2.0.0"
           }
         },
         "through2": {
@@ -6322,8 +6232,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "requires": {
-            "readable-stream": "2.3.3",
-            "xtend": "4.0.1"
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -6334,8 +6244,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
       }
     },
     "resolve": {
@@ -6343,7 +6253,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
       "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-from": {
@@ -6357,8 +6267,8 @@
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "requires": {
-        "exit-hook": "1.1.1",
-        "onetime": "1.1.0"
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
       }
     },
     "resumer": {
@@ -6366,7 +6276,7 @@
       "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
       "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
       "requires": {
-        "through": "2.3.8"
+        "through": "~2.3.4"
       },
       "dependencies": {
         "through": {
@@ -6381,7 +6291,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "run-async": {
@@ -6390,7 +6300,7 @@
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.3.0"
       }
     },
     "run-parallel": {
@@ -6421,14 +6331,14 @@
       "resolved": "https://registry.npmjs.org/scuttle-blog/-/scuttle-blog-1.0.1.tgz",
       "integrity": "sha512-Ga7gzKj+TwpdLrKm+A33tOM50qldSyz2zMwNFLsOKswsjpA/4CeAu/uV31FB0iqNTo9bjtQ7gzkexElaGIM5jg==",
       "requires": {
-        "is-my-json-valid": "2.17.2",
-        "libnested": "1.3.2",
-        "lodash": "4.17.10",
-        "mutant": "3.22.1",
-        "pull-stream": "3.6.8",
-        "ssb-about": "0.1.2",
-        "ssb-keys": "7.0.16",
-        "ssb-ref": "2.11.1"
+        "is-my-json-valid": "^2.17.1",
+        "libnested": "^1.2.1",
+        "lodash": "^4.17.4",
+        "mutant": "^3.22.1",
+        "pull-stream": "^3.6.1",
+        "ssb-about": "^0.1.2",
+        "ssb-keys": "^7.0.13",
+        "ssb-ref": "^2.9.1"
       },
       "dependencies": {
         "is-my-json-valid": {
@@ -6436,44 +6346,45 @@
           "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
           "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
           "requires": {
-            "generate-function": "2.0.0",
-            "generate-object-property": "1.2.0",
-            "is-my-ip-valid": "1.0.0",
-            "jsonpointer": "4.0.1",
-            "xtend": "4.0.1"
-          }
-        },
-        "ssb-ref": {
-          "version": "2.11.1",
-          "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.11.1.tgz",
-          "integrity": "sha512-K3L9hJ1v0HrH8abtEKiBkdeabHVaws+CS81mZqUfhR84i0dlYhiIIDwqeLxUj/1mLcsZPF3gMKPsFCUr7UAdMA==",
-          "requires": {
-            "ip": "1.1.5",
-            "is-valid-domain": "0.0.5"
+            "generate-function": "^2.0.0",
+            "generate-object-property": "^1.1.0",
+            "is-my-ip-valid": "^1.0.0",
+            "jsonpointer": "^4.0.0",
+            "xtend": "^4.0.0"
           }
         }
       }
     },
-    "scuttle-poll": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/scuttle-poll/-/scuttle-poll-1.2.0.tgz",
-      "integrity": "sha512-QyVLQ3bylt6JOlM0Q10CHA1K5NUFFVmgLu/o3KayQ7EiCVp1gwAz0F1vWt8ZPhp2ozvCcUAlxtqs7TyjmpIZcg==",
+    "scuttle-inject": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/scuttle-inject/-/scuttle-inject-1.0.3.tgz",
+      "integrity": "sha512-ddtx35eBLUxFWsDLj025gVCOIBkiU6GuxH05oES3O6e2VDUDwyfSiT/OtzkY9wDBNgJ2RkPxdtCqEBNEskk0Rw==",
       "requires": {
-        "is-my-json-valid": "2.17.2",
-        "libnested": "1.3.2",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.merge": "4.6.1",
-        "mutant": "3.22.1",
-        "pull-async": "1.0.0",
-        "pull-merge": "1.0.4",
-        "pull-next-query": "1.0.0",
-        "pull-paramap": "1.2.2",
-        "pull-stream": "3.6.8",
-        "ssb-msg-content": "1.0.1",
-        "ssb-msg-schemas": "6.3.0",
-        "ssb-poll-schema": "1.6.1",
-        "ssb-ref": "2.11.1",
-        "ssb-sort": "1.1.0"
+        "libnested": "^1.3.2",
+        "mutant": "^3.22.1",
+        "pull-defer": "^0.2.2"
+      }
+    },
+    "scuttle-poll": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/scuttle-poll/-/scuttle-poll-1.2.1.tgz",
+      "integrity": "sha512-x+WZHoBj+ci/07+cwXLA7iBChK+lh27AP0JuXsblWrO7NLQk/7XeiG5hfhNG0qMV9GE8sjW3h9ojLbRT95rNdQ==",
+      "requires": {
+        "is-my-json-valid": "^2.17.1",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.merge": "^4.6.1",
+        "mutant": "^3.22.1",
+        "pull-async": "^1.0.0",
+        "pull-merge": "^1.0.4",
+        "pull-next-query": "^1.0.0",
+        "pull-paramap": "^1.2.2",
+        "pull-stream": "^3.6.2",
+        "scuttle-inject": "^1.0.0",
+        "ssb-msg-content": "^1.0.1",
+        "ssb-msg-schemas": "^6.3.0",
+        "ssb-poll-schema": "^1.6.1",
+        "ssb-ref": "^2.9.0",
+        "ssb-sort": "^1.1.0"
       },
       "dependencies": {
         "is-my-json-valid": {
@@ -6481,655 +6392,106 @@
           "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
           "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
           "requires": {
-            "generate-function": "2.0.0",
-            "generate-object-property": "1.2.0",
-            "is-my-ip-valid": "1.0.0",
-            "jsonpointer": "4.0.1",
-            "xtend": "4.0.1"
-          }
-        },
-        "lodash.merge": {
-          "version": "4.6.1",
-          "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-          "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
-        },
-        "ssb-ref": {
-          "version": "2.11.1",
-          "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.11.1.tgz",
-          "integrity": "sha512-K3L9hJ1v0HrH8abtEKiBkdeabHVaws+CS81mZqUfhR84i0dlYhiIIDwqeLxUj/1mLcsZPF3gMKPsFCUr7UAdMA==",
-          "requires": {
-            "ip": "1.1.5",
-            "is-valid-domain": "0.0.5"
-          }
-        },
-        "ssb-sort": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/ssb-sort/-/ssb-sort-1.1.0.tgz",
-          "integrity": "sha512-UGn0GXkcpno7rNYWJhywmtKDnbhAHT3Nj++tMFP0pJ5shKL8SiipGYnjpZ8nVW185HNsEdsS06yJPD4o3hQyDQ==",
-          "requires": {
-            "ssb-ref": "2.11.1"
+            "generate-function": "^2.0.0",
+            "generate-object-property": "^1.1.0",
+            "is-my-ip-valid": "^1.0.0",
+            "jsonpointer": "^4.0.0",
+            "xtend": "^4.0.0"
           }
         }
       }
     },
     "scuttlebot": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/scuttlebot/-/scuttlebot-11.3.3.tgz",
-      "integrity": "sha512-1F2PVf1HfU3dbCwa5AxKbXEmMEhz0vlsetc5HoBkAr+L4U3SR9NaO+oPNa9NuUc9lVM1wqCrLjDU2nu824bGvQ==",
+      "version": "11.4.1",
+      "resolved": "https://registry.npmjs.org/scuttlebot/-/scuttlebot-11.4.1.tgz",
+      "integrity": "sha512-2W3PPcm553TCChI9o3ntN2ke2Q8YT4+GPf/aaazgQfhBxmZm67gZhJWvduD3f8Uhn18SMUPHeG7Kru2w02sDFw==",
       "requires": {
         "atomic-file": "0.0.1",
-        "bash-color": "0.0.4",
-        "broadcast-stream": "0.2.2",
-        "cont": "1.0.3",
-        "cross-spawn": "5.1.0",
-        "deep-equal": "1.0.1",
-        "explain-error": "1.0.4",
+        "bash-color": "~0.0.3",
+        "broadcast-stream": "^0.2.1",
+        "cont": "~1.0.3",
+        "cross-spawn": "^5.1.0",
+        "deep-equal": "^1.0.1",
+        "explain-error": "^1.0.3",
         "has-network": "0.0.1",
-        "ip": "0.3.3",
-        "mdmanifest": "1.0.8",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "multiblob": "1.13.0",
-        "multicb": "1.2.2",
-        "multiserver": "1.12.0",
-        "muxrpc": "6.4.0",
-        "muxrpc-validation": "2.0.1",
-        "muxrpcli": "1.1.0",
-        "mv": "2.1.1",
-        "non-private-ip": "1.4.4",
-        "observ-debounce": "1.1.1",
+        "ip": "^0.3.3",
+        "mdmanifest": "^1.0.4",
+        "minimist": "^1.1.3",
+        "mkdirp": "~0.5.0",
+        "multiblob": "^1.13.0",
+        "multicb": "^1.0.0",
+        "multiserver": "^1.12.0",
+        "muxrpc": "^6.4.0",
+        "muxrpc-validation": "^2.0.0",
+        "muxrpcli": "^1.0.0",
+        "mv": "^2.1.1",
+        "non-private-ip": "^1.4.3",
+        "observ-debounce": "^1.1.1",
         "obv": "0.0.1",
         "on-change-network": "0.0.2",
-        "on-wakeup": "1.0.1",
-        "osenv": "0.1.5",
-        "pull-abortable": "4.1.1",
-        "pull-cat": "1.1.11",
-        "pull-file": "1.0.0",
+        "on-wakeup": "^1.0.0",
+        "osenv": "^0.1.5",
+        "pull-abortable": "~4.1.0",
+        "pull-cat": "~1.1.5",
+        "pull-file": "^1.0.0",
         "pull-flatmap": "0.0.1",
-        "pull-inactivity": "2.1.2",
-        "pull-level": "2.0.3",
-        "pull-many": "1.0.8",
-        "pull-next": "1.0.1",
+        "pull-inactivity": "~2.1.1",
+        "pull-level": "^2.0.2",
+        "pull-many": "~1.0.6",
+        "pull-next": "^1.0.0",
         "pull-notify": "0.1.1",
-        "pull-paramap": "1.2.2",
-        "pull-ping": "2.0.2",
-        "pull-pushable": "2.2.0",
-        "pull-stream": "3.6.8",
-        "pull-stream-to-stream": "1.3.4",
-        "pull-stringify": "1.2.2",
-        "rimraf": "2.6.2",
-        "secret-stack": "4.1.0",
-        "secure-scuttlebutt": "18.1.1",
-        "ssb-blobs": "1.1.5",
-        "ssb-client": "4.5.7",
-        "ssb-config": "2.2.0",
-        "ssb-ebt": "5.2.2",
-        "ssb-friends": "2.4.0",
-        "ssb-keys": "7.0.16",
-        "ssb-links": "3.0.3",
-        "ssb-msgs": "5.2.0",
-        "ssb-query": "2.1.0",
-        "ssb-ref": "2.11.1",
-        "ssb-ws": "2.1.1",
-        "statistics": "3.3.0",
-        "stream-to-pull-stream": "1.7.2",
-        "zerr": "1.0.4"
+        "pull-paramap": "~1.2.1",
+        "pull-ping": "^2.0.2",
+        "pull-pushable": "^2.2.0",
+        "pull-stream": "^3.6.2",
+        "pull-stream-to-stream": "~1.3.0",
+        "pull-stringify": "~1.2.2",
+        "rimraf": "^2.4.2",
+        "secret-stack": "^4.1.0",
+        "secure-scuttlebutt": "^18.2.0",
+        "ssb-blobs": "^1.1.4",
+        "ssb-client": "^4.5.7",
+        "ssb-config": "^2.0.0",
+        "ssb-ebt": "^5.1.4",
+        "ssb-friends": "^2.4.0",
+        "ssb-keys": "^7.0.13",
+        "ssb-links": "^3.0.2",
+        "ssb-msgs": "~5.2.0",
+        "ssb-query": "^2.1.0",
+        "ssb-ref": "^2.9.1",
+        "ssb-ws": "^2.1.1",
+        "statistics": "^3.0.0",
+        "stream-to-pull-stream": "^1.6.10",
+        "zerr": "^1.0.0"
       },
       "dependencies": {
-        "abstract-leveldown": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-4.0.3.tgz",
-          "integrity": "sha512-qsIHFQy0u17JqSY+3ZUT+ykqxYY17yOfvAsLkFkw8kSQqi05d1jyj0bCuSX6sjYlXuY9cKpgUt5EudQdP4aXyA==",
-          "requires": {
-            "xtend": "4.0.1"
-          }
-        },
         "atomic-file": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/atomic-file/-/atomic-file-0.0.1.tgz",
           "integrity": "sha1-bDZlj2xOzjP7o4d3MefCX8gpmbs="
-        },
-        "bindings": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-          "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
-        },
-        "deep-extend": {
-          "version": "0.2.11",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
-          "integrity": "sha1-eha6aXKRMjQFBhcElLyD9wdv4I8="
-        },
-        "deferred-leveldown": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-3.0.0.tgz",
-          "integrity": "sha512-ajbXqRPMXRlcdyt0TuWqknOJkp1JgQjGB7xOl2V+ebol7/U11E9h3/nCZAtN1M7djmAJEIhypCUc1tIWxdQAuQ==",
-          "requires": {
-            "abstract-leveldown": "4.0.3"
-          }
-        },
-        "flumecodec": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/flumecodec/-/flumecodec-0.0.1.tgz",
-          "integrity": "sha1-rgSacUOGu4PjQmV6gpJLcDZKkNY=",
-          "requires": {
-            "level-codec": "6.2.0"
-          }
-        },
-        "flumelog-offset": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/flumelog-offset/-/flumelog-offset-3.3.1.tgz",
-          "integrity": "sha512-4yYdr8tTL0qOkKqhxAxvNnIwDBaBcLEsJWbyc2wU4Ycaewts9xxcBaxNbORp2KBbTwFaqZAV13HVpfZcO1X/AA==",
-          "requires": {
-            "aligned-block-file": "1.1.2",
-            "append-batch": "0.0.1",
-            "explain-error": "1.0.4",
-            "hashlru": "2.2.0",
-            "int53": "0.2.4",
-            "looper": "4.0.0",
-            "ltgt": "2.2.0",
-            "obv": "0.0.1",
-            "pull-cursor": "3.0.0",
-            "pull-looper": "1.0.0",
-            "uint48be": "1.0.2"
-          }
-        },
-        "flumeview-level": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/flumeview-level/-/flumeview-level-3.0.5.tgz",
-          "integrity": "sha512-LKW+YdJGemOo7TnUwpFHq4cBBiYAIKtWk+G2CK7zrxbCIiAHemBRudohBOUKuSUZZ0CReR5fJ73peBHW02VerA==",
-          "requires": {
-            "charwise": "3.0.1",
-            "explain-error": "1.0.4",
-            "level": "3.0.2",
-            "ltgt": "2.2.0",
-            "mkdirp": "0.5.1",
-            "obv": "0.0.0",
-            "pull-level": "2.0.3",
-            "pull-paramap": "1.2.2",
-            "pull-stream": "3.6.8",
-            "pull-write": "1.1.4"
-          },
-          "dependencies": {
-            "obv": {
-              "version": "0.0.0",
-              "resolved": "https://registry.npmjs.org/obv/-/obv-0.0.0.tgz",
-              "integrity": "sha1-7eq4Ro+R1BkzYu1/kdC5bdOaecE="
-            }
-          }
         },
         "ip": {
           "version": "0.3.3",
           "resolved": "https://registry.npmjs.org/ip/-/ip-0.3.3.tgz",
           "integrity": "sha1-jugwnpLwsEDSh/cu+soaIXAtP7Q="
         },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "level": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/level/-/level-3.0.2.tgz",
-          "integrity": "sha512-2qYbbiptPsPWGUI+AgB1gTNXqIjPpALRqrQyNx1zWYNZxhhuzEj/IE4Unu9weEBnsUEocfYe56xOGlAceb8/Fg==",
-          "requires": {
-            "level-packager": "2.1.1",
-            "leveldown": "3.0.2",
-            "opencollective-postinstall": "2.0.0"
-          }
-        },
-        "level-errors": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.1.2.tgz",
-          "integrity": "sha512-Sw/IJwWbPKF5Ai4Wz60B52yj0zYeqzObLh8k1Tk88jVmD51cJSKWSYpRyhVIvFzZdvsPqlH5wfhp/yxdsaQH4w==",
-          "requires": {
-            "errno": "0.1.4"
-          }
-        },
-        "level-iterator-stream": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.3.tgz",
-          "integrity": "sha512-I6Heg70nfF+e5Y3/qfthJFexhRw/Gi3bIymCoXAlijZdAcLaPuWSJs3KXyTYf23ID6g0o2QF62Yh+grOXY3Rig==",
-          "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.3",
-            "xtend": "4.0.1"
-          }
-        },
-        "level-packager": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-2.1.1.tgz",
-          "integrity": "sha512-6l3G6dVkmdvHwOJrEA9d9hL6SSFrzwjQoLP8HsvohOgfY/8Z9LyTKNCM5Gc84wtsUWCuIHu6r+S6WrCtTWUJCw==",
-          "requires": {
-            "encoding-down": "4.0.1",
-            "levelup": "2.0.2"
-          }
-        },
-        "level-sublevel": {
-          "version": "6.6.5",
-          "resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.5.tgz",
-          "integrity": "sha512-SBSR60x+dghhwGUxPKS+BvV1xNqnwsEUBKmnFepPaHJ6VkBXyPK9SImGc3K2BkwBfpxlt7GKkBNlCnrdufsejA==",
-          "requires": {
-            "bytewise": "1.1.0",
-            "levelup": "0.19.1",
-            "ltgt": "2.1.3",
-            "pull-defer": "0.2.2",
-            "pull-level": "2.0.3",
-            "pull-stream": "3.6.8",
-            "typewiselite": "1.0.0",
-            "xtend": "4.0.1"
-          },
-          "dependencies": {
-            "abstract-leveldown": {
-              "version": "0.12.4",
-              "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
-              "integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
-              "requires": {
-                "xtend": "3.0.0"
-              },
-              "dependencies": {
-                "xtend": {
-                  "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-                  "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
-                }
-              }
-            },
-            "deferred-leveldown": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-0.2.0.tgz",
-              "integrity": "sha1-LO8fER4cV4cNi7uK8mUOWHzS9bQ=",
-              "requires": {
-                "abstract-leveldown": "0.12.4"
-              }
-            },
-            "levelup": {
-              "version": "0.19.1",
-              "resolved": "https://registry.npmjs.org/levelup/-/levelup-0.19.1.tgz",
-              "integrity": "sha1-86anIFJyxLXzXkEv8ASgOgrt9Qs=",
-              "requires": {
-                "bl": "0.8.2",
-                "deferred-leveldown": "0.2.0",
-                "errno": "0.1.4",
-                "prr": "0.0.0",
-                "readable-stream": "1.0.34",
-                "semver": "5.1.1",
-                "xtend": "3.0.0"
-              },
-              "dependencies": {
-                "xtend": {
-                  "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-                  "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
-                }
-              }
-            },
-            "ltgt": {
-              "version": "2.1.3",
-              "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
-              "integrity": "sha1-EIUaBtmWS5cReEQcI8nlJpjuzjQ="
-            },
-            "readable-stream": {
-              "version": "1.0.34",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
-              }
-            },
-            "semver": {
-              "version": "5.1.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.1.tgz",
-              "integrity": "sha1-oykqNz5vPgeY2gsgZBuanFvEfhk="
-            }
-          }
-        },
-        "leveldown": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-3.0.2.tgz",
-          "integrity": "sha512-+ANRScj1npQQzv6e4DYAKRjVQZZ+ahMoubKrNP68nIq+l9bYgb+WiXF+14oTcQTg2f7qE9WHGW7rBG9nGSsA+A==",
-          "requires": {
-            "abstract-leveldown": "4.0.3",
-            "bindings": "1.3.0",
-            "fast-future": "1.0.2",
-            "nan": "2.10.0",
-            "prebuild-install": "4.0.0"
-          }
-        },
-        "levelup": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/levelup/-/levelup-2.0.2.tgz",
-          "integrity": "sha512-us+nTLUyd/eLnclYYddOCdAVw1hnymGx/9p4Jr5ThohStsjLqMVmbYiz6/SYFZEPXNF+AKQSvh6fA2e2KZpC8w==",
-          "requires": {
-            "deferred-leveldown": "3.0.0",
-            "level-errors": "1.1.2",
-            "level-iterator-stream": "2.0.3",
-            "xtend": "4.0.1"
-          }
-        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        },
-        "multiblob": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/multiblob/-/multiblob-1.13.0.tgz",
-          "integrity": "sha1-4oTV5KlE5yS+4uOJbLMAfwaaQbs=",
-          "requires": {
-            "blake2s": "1.0.1",
-            "cont": "1.0.3",
-            "explain-error": "1.0.4",
-            "mkdirp": "0.5.1",
-            "pull-cat": "1.1.11",
-            "pull-defer": "0.2.2",
-            "pull-file": "0.5.0",
-            "pull-glob": "1.0.6",
-            "pull-live": "1.0.1",
-            "pull-notify": "0.1.1",
-            "pull-paramap": "1.2.2",
-            "pull-stream": "3.6.8",
-            "pull-write-file": "0.2.4",
-            "rc": "0.5.5",
-            "rimraf": "2.2.8",
-            "stream-to-pull-stream": "1.7.2"
-          },
-          "dependencies": {
-            "pull-file": {
-              "version": "0.5.0",
-              "resolved": "https://registry.npmjs.org/pull-file/-/pull-file-0.5.0.tgz",
-              "integrity": "sha1-s8pAUwbggvnUUoKIkzutsrZWNls=",
-              "requires": {
-                "pull-utf8-decoder": "1.0.2"
-              }
-            },
-            "rimraf": {
-              "version": "2.2.8",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-              "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
-            }
-          }
-        },
-        "multiblob-http": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/multiblob-http/-/multiblob-http-0.4.2.tgz",
-          "integrity": "sha512-hVaXryaqJ3vvKjRNcOCEadzgO99nR+haxlptswr3vRvgavbK/Y/I7/Nat12WIQno2/A8+nkbE+ZcrsN3UDbtQw==",
-          "requires": {
-            "pull-stream": "3.6.8",
-            "stream-to-pull-stream": "1.7.2"
-          }
-        },
-        "multiserver": {
-          "version": "1.12.0",
-          "resolved": "https://registry.npmjs.org/multiserver/-/multiserver-1.12.0.tgz",
-          "integrity": "sha512-vyoVDqxiJabvepIKYN2+lYcPDcV5/de54kWXg1nYa1VK0NMJZ+gVIS6bLnQ9FmNzOxpCmVrVOkaQ0pMlMic5Ow==",
-          "requires": {
-            "pull-cat": "1.1.11",
-            "pull-stream": "3.6.8",
-            "pull-ws": "3.3.0",
-            "secret-handshake": "1.1.13",
-            "separator-escape": "0.0.0",
-            "socks": "1.1.9",
-            "stream-to-pull-stream": "1.7.2"
-          }
-        },
-        "muxrpc": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/muxrpc/-/muxrpc-6.4.0.tgz",
-          "integrity": "sha1-JPfaBpvUYpsHfpk7BXeUKyaI6ug=",
-          "requires": {
-            "explain-error": "1.0.4",
-            "packet-stream": "2.0.2",
-            "packet-stream-codec": "1.1.2",
-            "pull-goodbye": "0.0.2",
-            "pull-stream": "3.6.8"
-          }
-        },
-        "nan": {
-          "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
-        },
-        "node-abi": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.4.3.tgz",
-          "integrity": "sha512-b656V5C0628gOOA2kwcpNA/bxdlqYF9FvxJ+qqVX0ctdXNVZpS8J6xEUYir3WAKc7U0BH/NRlSpNbGsy+azjeg==",
-          "requires": {
-            "semver": "5.4.1"
-          }
-        },
-        "non-private-ip": {
-          "version": "1.4.4",
-          "resolved": "https://registry.npmjs.org/non-private-ip/-/non-private-ip-1.4.4.tgz",
-          "integrity": "sha512-K9nTVFOGUOYutaG8ywiKpCdVu458RFxSgSJ0rribUxtf5iLM9B2+raFJgkID3p5op0+twmoQqFaPnu9KYz6qzg==",
-          "requires": {
-            "ip": "1.1.5"
-          },
-          "dependencies": {
-            "ip": {
-              "version": "1.1.5",
-              "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-              "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
-            }
-          }
-        },
-        "osenv": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-          "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
-          }
-        },
-        "prebuild-install": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-4.0.0.tgz",
-          "integrity": "sha512-7tayxeYboJX0RbVzdnKyGl2vhQRWr6qfClEXDhOkXjuaOKCw2q8aiuFhONRYVsG/czia7KhpykIlI2S2VaPunA==",
-          "requires": {
-            "detect-libc": "1.0.3",
-            "expand-template": "1.1.0",
-            "github-from-package": "0.0.0",
-            "minimist": "1.2.0",
-            "mkdirp": "0.5.1",
-            "node-abi": "2.4.3",
-            "noop-logger": "0.1.1",
-            "npmlog": "4.1.2",
-            "os-homedir": "1.0.2",
-            "pump": "2.0.1",
-            "rc": "1.2.8",
-            "simple-get": "2.8.1",
-            "tar-fs": "1.16.0",
-            "tunnel-agent": "0.6.0",
-            "which-pm-runs": "1.0.0"
-          },
-          "dependencies": {
-            "deep-extend": {
-              "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-              "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
-            },
-            "rc": {
-              "version": "1.2.8",
-              "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-              "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-              "requires": {
-                "deep-extend": "0.6.0",
-                "ini": "1.3.5",
-                "minimist": "1.2.0",
-                "strip-json-comments": "2.0.1"
-              }
-            },
-            "strip-json-comments": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-            }
-          }
-        },
-        "pull-cont": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/pull-cont/-/pull-cont-0.0.0.tgz",
-          "integrity": "sha1-P6xIuBrJe3W6ATMgiLDOevjBvg4="
-        },
-        "pull-cursor": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pull-cursor/-/pull-cursor-3.0.0.tgz",
-          "integrity": "sha512-95lZVSF2eSEdOmUtlOBaD9p5YOvlYeCr5FBv2ySqcj/4rpaXI6d8OH+zPHHjKAf58R8QXJRZuyfHkcCX8TZbAg==",
-          "requires": {
-            "looper": "4.0.0",
-            "ltgt": "2.2.0",
-            "pull-stream": "3.6.8"
-          }
-        },
-        "pull-pushable": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.2.0.tgz",
-          "integrity": "sha1-Xy867UethpGfAbEqLpnW8b13ZYE="
-        },
-        "pump": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-          "requires": {
-            "end-of-stream": "1.4.0",
-            "once": "1.4.0"
-          }
-        },
-        "rc": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.5.tgz",
-          "integrity": "sha1-VBzDMA9GS23+ZDLXVvDy3T6esZk=",
-          "requires": {
-            "deep-extend": "0.2.11",
-            "ini": "1.3.5",
-            "minimist": "0.0.10",
-            "strip-json-comments": "0.1.3"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.10",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-              "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
-            }
-          }
-        },
-        "secret-handshake": {
-          "version": "1.1.13",
-          "resolved": "https://registry.npmjs.org/secret-handshake/-/secret-handshake-1.1.13.tgz",
-          "integrity": "sha512-jDpA1kPJGg+jEUOZGvqksQFGPWIx0aA96HpjU+AqIBKIKzmvZeOq0Lfl/XqVC5jviWTVZZM2B8+NqYR38Blz8A==",
-          "requires": {
-            "chloride": "2.2.8",
-            "deep-equal": "1.0.1",
-            "pull-box-stream": "1.0.13",
-            "pull-handshake": "1.1.4",
-            "pull-stream": "3.6.8"
-          }
-        },
-        "secure-scuttlebutt": {
-          "version": "18.1.1",
-          "resolved": "https://registry.npmjs.org/secure-scuttlebutt/-/secure-scuttlebutt-18.1.1.tgz",
-          "integrity": "sha512-mK0Wims55gi6blMLCb2vKZui+K5AgJMxGiGD7pnXIkUt6URn7SSShC7FNaL+w/Vnmld+No9iyIonZGJlytqKqA==",
-          "requires": {
-            "async-write": "2.1.0",
-            "cont": "1.0.3",
-            "deep-equal": "0.2.2",
-            "explain-error": "1.0.4",
-            "flumecodec": "0.0.1",
-            "flumedb": "0.4.2",
-            "flumelog-offset": "3.3.1",
-            "flumeview-hashtable": "1.0.4",
-            "flumeview-level": "3.0.5",
-            "flumeview-reduce": "1.3.9",
-            "level": "3.0.2",
-            "level-sublevel": "6.6.5",
-            "ltgt": "2.2.0",
-            "monotonic-timestamp": "0.0.9",
-            "obv": "0.0.1",
-            "pull-cont": "0.0.0",
-            "pull-level": "2.0.3",
-            "pull-live": "1.0.1",
-            "pull-notify": "0.1.1",
-            "pull-paramap": "1.2.2",
-            "pull-stream": "3.6.8",
-            "ssb-keys": "7.0.16",
-            "ssb-msgs": "5.2.0",
-            "ssb-ref": "2.11.1",
-            "ssb-validate": "3.0.10",
-            "typewiselite": "1.0.0"
-          },
-          "dependencies": {
-            "deep-equal": {
-              "version": "0.2.2",
-              "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
-              "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0="
-            }
-          }
-        },
-        "simple-get": {
-          "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
-          "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
-          "requires": {
-            "decompress-response": "3.3.0",
-            "once": "1.4.0",
-            "simple-concat": "1.0.0"
-          }
-        },
-        "ssb-ref": {
-          "version": "2.11.1",
-          "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.11.1.tgz",
-          "integrity": "sha512-K3L9hJ1v0HrH8abtEKiBkdeabHVaws+CS81mZqUfhR84i0dlYhiIIDwqeLxUj/1mLcsZPF3gMKPsFCUr7UAdMA==",
-          "requires": {
-            "ip": "1.1.5",
-            "is-valid-domain": "0.0.5"
-          },
-          "dependencies": {
-            "ip": {
-              "version": "1.1.5",
-              "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-              "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
-            }
-          }
-        },
-        "ssb-ws": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ssb-ws/-/ssb-ws-2.1.1.tgz",
-          "integrity": "sha512-1fK/jXI6lKZadRJDr49t+6yMmWynp6PFrADs3Whmy8IslnYGl83ujhlpRIBvCn1EuVHjV7yLsIiJ8a0X2Kg0DQ==",
-          "requires": {
-            "emoji-server": "1.0.0",
-            "multiblob-http": "0.4.2",
-            "multiserver": "1.12.0",
-            "muxrpc": "6.4.0",
-            "pull-box-stream": "1.0.13",
-            "ssb-ref": "2.11.1",
-            "stack": "0.1.0"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        },
-        "strip-json-comments": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz",
-          "integrity": "sha1-Fkxk43Coo8wAyeAbU55WmCPw7lQ="
         }
       }
     },
     "secret-handshake": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/secret-handshake/-/secret-handshake-1.1.11.tgz",
-      "integrity": "sha1-I51hNnjx5cUPIj8mBfNkdc79Zl4=",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/secret-handshake/-/secret-handshake-1.1.13.tgz",
+      "integrity": "sha512-jDpA1kPJGg+jEUOZGvqksQFGPWIx0aA96HpjU+AqIBKIKzmvZeOq0Lfl/XqVC5jviWTVZZM2B8+NqYR38Blz8A==",
       "requires": {
-        "chloride": "2.2.8",
-        "deep-equal": "1.0.1",
-        "pull-box-stream": "1.0.13",
-        "pull-handshake": "1.1.4",
-        "pull-stream": "3.6.8"
+        "chloride": "^2.2.7",
+        "deep-equal": "~1.0.0",
+        "pull-box-stream": "^1.0.13",
+        "pull-handshake": "^1.1.1",
+        "pull-stream": "^3.4.5"
       }
     },
     "secret-stack": {
@@ -7138,69 +6500,74 @@
       "integrity": "sha512-tCxjylkvEvUqxlWSVALtPMGKGyed225oDf7zoxCOsvj5SaVolUzOaixS07IK74mjcq7D1TvEJ4kofcaTMhQq1w==",
       "requires": {
         "hoox": "0.0.1",
-        "ip": "1.1.5",
-        "map-merge": "1.1.0",
-        "multiserver": "1.12.0",
-        "muxrpc": "6.4.0",
-        "non-private-ip": "1.4.4",
-        "pull-inactivity": "2.1.2",
-        "pull-rate": "1.0.2",
-        "pull-stream": "3.6.8",
-        "stream-to-pull-stream": "1.7.2"
-      },
-      "dependencies": {
-        "multiserver": {
-          "version": "1.12.0",
-          "resolved": "https://registry.npmjs.org/multiserver/-/multiserver-1.12.0.tgz",
-          "integrity": "sha512-vyoVDqxiJabvepIKYN2+lYcPDcV5/de54kWXg1nYa1VK0NMJZ+gVIS6bLnQ9FmNzOxpCmVrVOkaQ0pMlMic5Ow==",
-          "requires": {
-            "pull-cat": "1.1.11",
-            "pull-stream": "3.6.8",
-            "pull-ws": "3.3.0",
-            "secret-handshake": "1.1.13",
-            "separator-escape": "0.0.0",
-            "socks": "1.1.9",
-            "stream-to-pull-stream": "1.7.2"
-          }
-        },
-        "muxrpc": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/muxrpc/-/muxrpc-6.4.0.tgz",
-          "integrity": "sha1-JPfaBpvUYpsHfpk7BXeUKyaI6ug=",
-          "requires": {
-            "explain-error": "1.0.4",
-            "packet-stream": "2.0.2",
-            "packet-stream-codec": "1.1.2",
-            "pull-goodbye": "0.0.2",
-            "pull-stream": "3.6.8"
-          }
-        },
-        "non-private-ip": {
-          "version": "1.4.4",
-          "resolved": "https://registry.npmjs.org/non-private-ip/-/non-private-ip-1.4.4.tgz",
-          "integrity": "sha512-K9nTVFOGUOYutaG8ywiKpCdVu458RFxSgSJ0rribUxtf5iLM9B2+raFJgkID3p5op0+twmoQqFaPnu9KYz6qzg==",
-          "requires": {
-            "ip": "1.1.5"
-          }
-        },
-        "secret-handshake": {
-          "version": "1.1.13",
-          "resolved": "https://registry.npmjs.org/secret-handshake/-/secret-handshake-1.1.13.tgz",
-          "integrity": "sha512-jDpA1kPJGg+jEUOZGvqksQFGPWIx0aA96HpjU+AqIBKIKzmvZeOq0Lfl/XqVC5jviWTVZZM2B8+NqYR38Blz8A==",
-          "requires": {
-            "chloride": "2.2.8",
-            "deep-equal": "1.0.1",
-            "pull-box-stream": "1.0.13",
-            "pull-handshake": "1.1.4",
-            "pull-stream": "3.6.8"
-          }
-        }
+        "ip": "^1.1.5",
+        "map-merge": "^1.1.0",
+        "multiserver": "^1.11.0",
+        "muxrpc": "^6.4.0",
+        "non-private-ip": "^1.4.3",
+        "pull-inactivity": "~2.1.1",
+        "pull-rate": "^1.0.2",
+        "pull-stream": "^3.4.5",
+        "stream-to-pull-stream": "^1.6.1"
       }
     },
     "secrets.js": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/secrets.js/-/secrets.js-0.1.8.tgz",
       "integrity": "sha1-WwUX+tx6jvcggqidqiE6P0CutaQ="
+    },
+    "secure-scuttlebutt": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/secure-scuttlebutt/-/secure-scuttlebutt-18.2.0.tgz",
+      "integrity": "sha512-rBK6P3A4MsZI4lrzaf/dbJJDIxuJXO6y3GUeNngb5IJlcagCNJ+zNZcd19rDURfU8tMgOyw+rEwGIs2ExLQTdg==",
+      "requires": {
+        "async-write": "^2.1.0",
+        "cont": "~1.0.0",
+        "deep-equal": "~0.2.1",
+        "explain-error": "~1.0.1",
+        "flumecodec": "0.0.1",
+        "flumedb": "^0.4.2",
+        "flumelog-offset": "^3.3.1",
+        "flumeview-hashtable": "^1.0.3",
+        "flumeview-level": "^3.0.5",
+        "flumeview-reduce": "^1.3.9",
+        "level": "^3.0.1",
+        "level-sublevel": "^6.6.2",
+        "ltgt": "^2.2.0",
+        "monotonic-timestamp": "~0.0.8",
+        "obv": "0.0.1",
+        "pull-cont": "0.0.0",
+        "pull-level": "^2.0.3",
+        "pull-live": "^1.0.1",
+        "pull-notify": "^0.1.0",
+        "pull-paramap": "^1.1.6",
+        "pull-stream": "^3.4.0",
+        "ssb-keys": "^7.0.15",
+        "ssb-msgs": "^5.0.0",
+        "ssb-ref": "^2.0.0",
+        "ssb-validate": "^3.0.1",
+        "typewiselite": "^1.0.0"
+      },
+      "dependencies": {
+        "deep-equal": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
+          "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0="
+        },
+        "flumecodec": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/flumecodec/-/flumecodec-0.0.1.tgz",
+          "integrity": "sha1-rgSacUOGu4PjQmV6gpJLcDZKkNY=",
+          "requires": {
+            "level-codec": "^6.2.0"
+          }
+        },
+        "pull-cont": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/pull-cont/-/pull-cont-0.0.0.tgz",
+          "integrity": "sha1-P6xIuBrJe3W6ATMgiLDOevjBvg4="
+        }
+      }
     },
     "semver": {
       "version": "5.4.1",
@@ -7232,7 +6599,7 @@
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.5.tgz",
       "integrity": "sha1-J9Fx78yCoRi5ljn/WBZgJCtQbnw=",
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "^2.0.1"
       }
     },
     "shallow-copy": {
@@ -7245,7 +6612,7 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -7259,9 +6626,9 @@
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "interpret": "1.0.4",
-        "rechoir": "0.6.2"
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
       }
     },
     "shellsubstitute": {
@@ -7279,6 +6646,16 @@
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
       "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
     },
+    "simple-get": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
+      "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
+      "requires": {
+        "decompress-response": "^3.3.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "simple-mime": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/simple-mime/-/simple-mime-0.1.0.tgz",
@@ -7290,7 +6667,7 @@
       "integrity": "sha1-wvg/Jzo+GhbtsJlWYdoO1e8DM2Q=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.1"
       }
     },
     "slash": {
@@ -7314,18 +6691,19 @@
       "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.9.tgz",
       "integrity": "sha1-Yo1+TQSRJDVEWsC25Fk3bLPm1pE=",
       "requires": {
-        "ip": "1.1.5",
-        "smart-buffer": "1.1.15"
+        "ip": "^1.1.2",
+        "smart-buffer": "^1.0.4"
       }
     },
     "sodium-browserify": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/sodium-browserify/-/sodium-browserify-1.2.1.tgz",
-      "integrity": "sha1-sLVZyjaYFnkIUhSFXiZkXfZ6rxw=",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sodium-browserify/-/sodium-browserify-1.2.4.tgz",
+      "integrity": "sha512-IYcxKje/uf/c3a7VhZYJLlUxWMcktfbD4AjqHjUD1/VWKjj0Oq5wNbX8wjJOWVO9UhUMqJQiOn2xFbzKWBmy5w==",
       "requires": {
-        "libsodium-wrappers": "0.2.12",
+        "libsodium-wrappers": "^0.7.3",
         "sha.js": "2.4.5",
-        "tweetnacl": "0.14.5"
+        "sodium-browserify-tweetnacl": "^0.2.3",
+        "tweetnacl": "^0.14.1"
       }
     },
     "sodium-browserify-tweetnacl": {
@@ -7333,20 +6711,20 @@
       "resolved": "https://registry.npmjs.org/sodium-browserify-tweetnacl/-/sodium-browserify-tweetnacl-0.2.3.tgz",
       "integrity": "sha1-tVN//LufdOvEQ7i2ohGykej8vI4=",
       "requires": {
-        "chloride-test": "1.2.2",
-        "ed2curve": "0.1.4",
-        "sha.js": "2.4.9",
-        "tweetnacl": "0.14.5",
-        "tweetnacl-auth": "0.3.1"
+        "chloride-test": "^1.1.0",
+        "ed2curve": "^0.1.4",
+        "sha.js": "^2.4.8",
+        "tweetnacl": "^0.14.1",
+        "tweetnacl-auth": "^0.3.0"
       },
       "dependencies": {
         "sha.js": {
-          "version": "2.4.9",
-          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.9.tgz",
-          "integrity": "sha512-G8zektVqbiPHrylgew9Zg1VRB1L/DtXNUVAM6q4QLy8NE3qtHlFXTf8VLL4k1Yl6c7NMjtZUTdXV+X44nFaT6A==",
+          "version": "2.4.11",
+          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+          "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
           "requires": {
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.2"
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         }
       }
@@ -7357,13 +6735,14 @@
       "integrity": "sha1-JHojS4iGf23/UTMrYF8ZOmW/aDk="
     },
     "sodium-native": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-2.0.1.tgz",
-      "integrity": "sha512-3xi2SbjeEUivlH4zPaBIaxQtpAInq4T3zX9kaeDquzgXRv96QLbTR0AcJeqXj3JeKdhwJ6YiLS3XFrnMp4tc+w==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-2.1.6.tgz",
+      "integrity": "sha512-vfovcNlU8C93SbeNoGSAdW5zVOTlrh1sTy+TzdC2FhDTE/IUK6j4ML5gdr/qziLz4XRT4EQWJvbFzql6CAAH/A==",
       "optional": true,
       "requires": {
-        "nan": "2.8.0",
-        "node-gyp-build": "3.2.2"
+        "ini": "^1.3.5",
+        "nan": "^2.4.0",
+        "node-gyp-build": "^3.0.0"
       }
     },
     "sorted-array-functions": {
@@ -7377,7 +6756,7 @@
       "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
       "optional": true,
       "requires": {
-        "amdefine": "1.0.1"
+        "amdefine": ">=0.0.4"
       }
     },
     "source-map-support": {
@@ -7385,7 +6764,7 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "^0.5.6"
       },
       "dependencies": {
         "source-map": {
@@ -7406,8 +6785,8 @@
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "3.0.0",
-        "spdx-license-ids": "3.0.0"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -7422,8 +6801,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "2.1.0",
-        "spdx-license-ids": "3.0.0"
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -7454,8 +6833,8 @@
       "resolved": "https://registry.npmjs.org/ssb-about/-/ssb-about-0.1.2.tgz",
       "integrity": "sha512-/dvDJZdvukOHTjWDAUDdi5euG3fHIgW0z8xIWI+n+C3ugDCPad24josbRBMtgJ6e5piKOzstTlumIqfekvv8YQ==",
       "requires": {
-        "flumeview-reduce": "1.3.9",
-        "ssb-ref": "2.8.0"
+        "flumeview-reduce": "^1.3.9",
+        "ssb-ref": "^2.7.1"
       }
     },
     "ssb-avatar": {
@@ -7463,10 +6842,10 @@
       "resolved": "https://registry.npmjs.org/ssb-avatar/-/ssb-avatar-0.2.0.tgz",
       "integrity": "sha1-Bs1weV7ljRRi0QCkXGYN8xedOzk=",
       "requires": {
-        "pull-cat": "1.1.11",
-        "pull-stream": "3.6.8",
-        "ssb-msgs": "5.2.0",
-        "ssb-ref": "2.8.0"
+        "pull-cat": "^1.1.9",
+        "pull-stream": "^3.4.3",
+        "ssb-msgs": "^5.2.0",
+        "ssb-ref": "^2.3.2"
       }
     },
     "ssb-backlinks": {
@@ -7474,29 +6853,13 @@
       "resolved": "https://registry.npmjs.org/ssb-backlinks/-/ssb-backlinks-0.7.3.tgz",
       "integrity": "sha512-84s5phSVyZsYV0FTmBJvICPgOMuu8ouzukG8Gz2XtuOui95GBP/G7UIBURgYVS82XA6g9xPA/jf38fsMxid38Q==",
       "requires": {
-        "base64-url": "2.2.0",
-        "deep-equal": "1.0.1",
-        "flumeview-query": "6.2.0",
-        "pull-stream": "3.6.8",
-        "ssb-keys": "7.0.16",
-        "ssb-ref": "2.11.1",
-        "xtend": "4.0.1"
-      },
-      "dependencies": {
-        "base64-url": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-2.2.0.tgz",
-          "integrity": "sha512-Y4qHHAE+rWjmAFPQmHPiiD+hWwM/XvuFLlP6kVxlwZJK7rjiE2uIQR9tZ37iEr1E6iCj9799yxMAmiXzITb3lQ=="
-        },
-        "ssb-ref": {
-          "version": "2.11.1",
-          "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.11.1.tgz",
-          "integrity": "sha512-K3L9hJ1v0HrH8abtEKiBkdeabHVaws+CS81mZqUfhR84i0dlYhiIIDwqeLxUj/1mLcsZPF3gMKPsFCUr7UAdMA==",
-          "requires": {
-            "ip": "1.1.5",
-            "is-valid-domain": "0.0.5"
-          }
-        }
+        "base64-url": "^2.2.0",
+        "deep-equal": "^1.0.1",
+        "flumeview-query": "^6.2.0",
+        "pull-stream": "^3.6.7",
+        "ssb-keys": "^7.0.14",
+        "ssb-ref": "^2.9.0",
+        "xtend": "^4.0.1"
       }
     },
     "ssb-blobs": {
@@ -7504,177 +6867,13 @@
       "resolved": "https://registry.npmjs.org/ssb-blobs/-/ssb-blobs-1.1.5.tgz",
       "integrity": "sha512-DeeInkFU8oN1mYlPVrqrm9tupf6wze4HuowK7N2vv/O+UeSLuYPU1p4HrxSqdAPvUabr0OtvbFA6z1T4nw+9fw==",
       "requires": {
-        "cont": "1.0.3",
-        "level": "3.0.2",
-        "multiblob": "1.13.0",
-        "pull-level": "2.0.4",
-        "pull-notify": "0.1.1",
-        "pull-stream": "3.6.8",
-        "ssb-ref": "2.8.0"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-4.0.3.tgz",
-          "integrity": "sha512-qsIHFQy0u17JqSY+3ZUT+ykqxYY17yOfvAsLkFkw8kSQqi05d1jyj0bCuSX6sjYlXuY9cKpgUt5EudQdP4aXyA==",
-          "requires": {
-            "xtend": "4.0.1"
-          }
-        },
-        "bindings": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-          "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
-        },
-        "deferred-leveldown": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-3.0.0.tgz",
-          "integrity": "sha512-ajbXqRPMXRlcdyt0TuWqknOJkp1JgQjGB7xOl2V+ebol7/U11E9h3/nCZAtN1M7djmAJEIhypCUc1tIWxdQAuQ==",
-          "requires": {
-            "abstract-leveldown": "4.0.3"
-          }
-        },
-        "level": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/level/-/level-3.0.2.tgz",
-          "integrity": "sha512-2qYbbiptPsPWGUI+AgB1gTNXqIjPpALRqrQyNx1zWYNZxhhuzEj/IE4Unu9weEBnsUEocfYe56xOGlAceb8/Fg==",
-          "requires": {
-            "level-packager": "2.1.1",
-            "leveldown": "3.0.2",
-            "opencollective-postinstall": "2.0.0"
-          }
-        },
-        "level-errors": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.1.2.tgz",
-          "integrity": "sha512-Sw/IJwWbPKF5Ai4Wz60B52yj0zYeqzObLh8k1Tk88jVmD51cJSKWSYpRyhVIvFzZdvsPqlH5wfhp/yxdsaQH4w==",
-          "requires": {
-            "errno": "0.1.4"
-          }
-        },
-        "level-iterator-stream": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.3.tgz",
-          "integrity": "sha512-I6Heg70nfF+e5Y3/qfthJFexhRw/Gi3bIymCoXAlijZdAcLaPuWSJs3KXyTYf23ID6g0o2QF62Yh+grOXY3Rig==",
-          "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.3",
-            "xtend": "4.0.1"
-          }
-        },
-        "level-packager": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-2.1.1.tgz",
-          "integrity": "sha512-6l3G6dVkmdvHwOJrEA9d9hL6SSFrzwjQoLP8HsvohOgfY/8Z9LyTKNCM5Gc84wtsUWCuIHu6r+S6WrCtTWUJCw==",
-          "requires": {
-            "encoding-down": "4.0.1",
-            "levelup": "2.0.2"
-          }
-        },
-        "level-post": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.7.tgz",
-          "integrity": "sha512-PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==",
-          "requires": {
-            "ltgt": "2.2.0"
-          }
-        },
-        "leveldown": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-3.0.2.tgz",
-          "integrity": "sha512-+ANRScj1npQQzv6e4DYAKRjVQZZ+ahMoubKrNP68nIq+l9bYgb+WiXF+14oTcQTg2f7qE9WHGW7rBG9nGSsA+A==",
-          "requires": {
-            "abstract-leveldown": "4.0.3",
-            "bindings": "1.3.0",
-            "fast-future": "1.0.2",
-            "nan": "2.10.0",
-            "prebuild-install": "4.0.0"
-          }
-        },
-        "levelup": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/levelup/-/levelup-2.0.2.tgz",
-          "integrity": "sha512-us+nTLUyd/eLnclYYddOCdAVw1hnymGx/9p4Jr5ThohStsjLqMVmbYiz6/SYFZEPXNF+AKQSvh6fA2e2KZpC8w==",
-          "requires": {
-            "deferred-leveldown": "3.0.0",
-            "level-errors": "1.1.2",
-            "level-iterator-stream": "2.0.3",
-            "xtend": "4.0.1"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        },
-        "nan": {
-          "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
-        },
-        "node-abi": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.4.3.tgz",
-          "integrity": "sha512-b656V5C0628gOOA2kwcpNA/bxdlqYF9FvxJ+qqVX0ctdXNVZpS8J6xEUYir3WAKc7U0BH/NRlSpNbGsy+azjeg==",
-          "requires": {
-            "semver": "5.4.1"
-          }
-        },
-        "prebuild-install": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-4.0.0.tgz",
-          "integrity": "sha512-7tayxeYboJX0RbVzdnKyGl2vhQRWr6qfClEXDhOkXjuaOKCw2q8aiuFhONRYVsG/czia7KhpykIlI2S2VaPunA==",
-          "requires": {
-            "detect-libc": "1.0.3",
-            "expand-template": "1.1.0",
-            "github-from-package": "0.0.0",
-            "minimist": "1.2.0",
-            "mkdirp": "0.5.1",
-            "node-abi": "2.4.3",
-            "noop-logger": "0.1.1",
-            "npmlog": "4.1.2",
-            "os-homedir": "1.0.2",
-            "pump": "2.0.1",
-            "rc": "1.2.2",
-            "simple-get": "2.8.1",
-            "tar-fs": "1.16.0",
-            "tunnel-agent": "0.6.0",
-            "which-pm-runs": "1.0.0"
-          }
-        },
-        "pull-level": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.4.tgz",
-          "integrity": "sha512-fW6pljDeUThpq5KXwKbRG3X7Ogk3vc75d5OQU/TvXXui65ykm+Bn+fiktg+MOx2jJ85cd+sheufPL+rw9QSVZg==",
-          "requires": {
-            "level-post": "1.0.7",
-            "pull-cat": "1.1.11",
-            "pull-live": "1.0.1",
-            "pull-pushable": "2.1.1",
-            "pull-stream": "3.6.8",
-            "pull-window": "2.1.4",
-            "stream-to-pull-stream": "1.7.2"
-          }
-        },
-        "pump": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-          "requires": {
-            "end-of-stream": "1.4.0",
-            "once": "1.4.0"
-          }
-        },
-        "simple-get": {
-          "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
-          "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
-          "requires": {
-            "decompress-response": "3.3.0",
-            "once": "1.4.0",
-            "simple-concat": "1.0.0"
-          }
-        }
+        "cont": "^1.0.3",
+        "level": "^3.0.0",
+        "multiblob": "^1.12.0",
+        "pull-level": "^2.0.4",
+        "pull-notify": "^0.1.0",
+        "pull-stream": "^3.3.0",
+        "ssb-ref": "^2.3.0"
       }
     },
     "ssb-chess": {
@@ -7682,28 +6881,28 @@
       "resolved": "https://registry.npmjs.org/ssb-chess/-/ssb-chess-2.2.11.tgz",
       "integrity": "sha512-8qrMhAwThxIWEh+GQLk7F5A72sZZhWX9QqpelSI/yXkvi3zlxYMqNh8Be+RWDVCzPVQ/lgQf/rPrK+w7YshXmw==",
       "requires": {
-        "bluebird": "3.5.1",
+        "bluebird": "^3.5.1",
         "chessground": "7.3.2",
         "depject": "4.1.0",
         "depnest": "1.3.0",
-        "howler": "2.0.14",
+        "howler": "^2.0.7",
         "hyperscript": "2.0.2",
-        "lodash": "4.17.10",
+        "lodash": "^4.17.4",
         "mithril": "1.1.1",
         "mutant": "3.19.0",
-        "mutant-pull-reduce": "1.1.0",
+        "mutant-pull-reduce": "^1.1.0",
         "neodoc": "1.4.0",
-        "patchcore": "1.28.0",
+        "patchcore": "^1.28.0",
         "pubsub-js": "1.5.7",
         "pull-abortable": "4.1.1",
-        "pull-async-filter": "1.0.0",
-        "pull-cat": "1.1.11",
-        "pull-many": "1.0.8",
+        "pull-async-filter": "^1.0.0",
+        "pull-cat": "^1.1.11",
+        "pull-many": "^1.0.8",
         "pull-scroll": "1.0.9",
         "pull-stream": "3.6.0",
         "ramda": "0.24.1",
         "ssb-embedded-chat": "1.1.1",
-        "ssb-ooo-about": "1.0.0",
+        "ssb-ooo-about": "^1.0.0",
         "tiny-worker": "2.1.1",
         "uuid": "3.1.0"
       },
@@ -7713,7 +6912,7 @@
           "resolved": "https://registry.npmjs.org/depject/-/depject-4.1.0.tgz",
           "integrity": "sha1-nJbqrazRaLrbQIeUv1+GeJg84YM=",
           "requires": {
-            "libnested": "1.3.2"
+            "libnested": "^1.1.0"
           }
         },
         "html-element": {
@@ -7721,7 +6920,7 @@
           "resolved": "https://registry.npmjs.org/html-element/-/html-element-2.2.0.tgz",
           "integrity": "sha1-w8H/iMJh23TQr2OR7vkMNG+QBzA=",
           "requires": {
-            "class-list": "0.1.1"
+            "class-list": "~0.1.1"
           }
         },
         "hyperscript": {
@@ -7730,8 +6929,8 @@
           "integrity": "sha1-ODnLpFVUvf4nu4HCFC0WhPgTWvU=",
           "requires": {
             "browser-split": "0.0.0",
-            "class-list": "0.1.1",
-            "html-element": "2.2.0"
+            "class-list": "~0.1.0",
+            "html-element": "^2.0.0"
           }
         },
         "mutant": {
@@ -7740,7 +6939,7 @@
           "integrity": "sha1-UQRlcyJJRSUQ9RLoTpVmMDV2Vjg=",
           "requires": {
             "browser-split": "0.0.1",
-            "xtend": "4.0.1"
+            "xtend": "^4.0.1"
           },
           "dependencies": {
             "browser-split": {
@@ -7767,10 +6966,10 @@
       "resolved": "https://registry.npmjs.org/ssb-chess-db/-/ssb-chess-db-1.0.2.tgz",
       "integrity": "sha512-zzN4PSSe7j1Pt1JGCUItFoMZdKUxnSxXOvU4gGXUqB32xKQaYPDQW8kTs+euQ15nWHgMa4kLxp7wLMxrS7uynQ==",
       "requires": {
-        "flumeview-reduce": "1.3.9",
-        "pull-defer": "0.2.2",
-        "pull-iterable": "0.1.0",
-        "pull-stream": "3.6.8"
+        "flumeview-reduce": "^1.3.8",
+        "pull-defer": "^0.2.2",
+        "pull-iterable": "^0.1.0",
+        "pull-stream": "^3.6.1"
       }
     },
     "ssb-client": {
@@ -7778,28 +6977,14 @@
       "resolved": "https://registry.npmjs.org/ssb-client/-/ssb-client-4.5.7.tgz",
       "integrity": "sha512-mEOyMlX6sGEUStU02vdSPD4j9ZRQQe3WCQwZCtgOkkrJpp7ARHxC0dx8ahumyq/vUIYWqQSAHHMD0+R63GmpGg==",
       "requires": {
-        "explain-error": "1.0.4",
-        "multicb": "1.2.2",
-        "multiserver": "1.10.0",
-        "muxrpc": "6.4.0",
-        "pull-hash": "1.0.0",
-        "pull-stream": "3.6.8",
-        "ssb-config": "2.2.0",
-        "ssb-keys": "7.0.16"
-      },
-      "dependencies": {
-        "muxrpc": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/muxrpc/-/muxrpc-6.4.0.tgz",
-          "integrity": "sha1-JPfaBpvUYpsHfpk7BXeUKyaI6ug=",
-          "requires": {
-            "explain-error": "1.0.4",
-            "packet-stream": "2.0.2",
-            "packet-stream-codec": "1.1.2",
-            "pull-goodbye": "0.0.2",
-            "pull-stream": "3.6.8"
-          }
-        }
+        "explain-error": "^1.0.1",
+        "multicb": "^1.2.1",
+        "multiserver": "^1.7.0",
+        "muxrpc": "^6.4.0",
+        "pull-hash": "^1.0.0",
+        "pull-stream": "^3.6.0",
+        "ssb-config": "^2.2.0",
+        "ssb-keys": "^7.0.13"
       }
     },
     "ssb-config": {
@@ -7807,10 +6992,10 @@
       "resolved": "https://registry.npmjs.org/ssb-config/-/ssb-config-2.2.0.tgz",
       "integrity": "sha1-QcrQOKhXWvQGLT/VfTsWe+hbA7w=",
       "requires": {
-        "deep-extend": "0.4.2",
-        "non-private-ip": "1.4.2",
-        "os-homedir": "1.0.2",
-        "rc": "1.2.2"
+        "deep-extend": "^0.4.0",
+        "non-private-ip": "^1.2.1",
+        "os-homedir": "^1.0.1",
+        "rc": "^1.1.6"
       }
     },
     "ssb-ebt": {
@@ -7818,28 +7003,12 @@
       "resolved": "https://registry.npmjs.org/ssb-ebt/-/ssb-ebt-5.2.2.tgz",
       "integrity": "sha512-De3dUnmgs/8aYl2fmi/MtJljR9qw1mUmpdM4qeCf+4uniqlNNhfn1Ux+M5A8XYVuI+TD4GkgmIDeZH6miey2kw==",
       "requires": {
-        "base64-url": "2.2.0",
-        "epidemic-broadcast-trees": "6.3.3",
-        "lossy-store": "1.2.3",
-        "pull-stream": "3.6.8",
-        "push-stream-to-pull-stream": "1.0.1",
-        "ssb-ref": "2.11.1"
-      },
-      "dependencies": {
-        "base64-url": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-2.2.0.tgz",
-          "integrity": "sha512-Y4qHHAE+rWjmAFPQmHPiiD+hWwM/XvuFLlP6kVxlwZJK7rjiE2uIQR9tZ37iEr1E6iCj9799yxMAmiXzITb3lQ=="
-        },
-        "ssb-ref": {
-          "version": "2.11.1",
-          "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.11.1.tgz",
-          "integrity": "sha512-K3L9hJ1v0HrH8abtEKiBkdeabHVaws+CS81mZqUfhR84i0dlYhiIIDwqeLxUj/1mLcsZPF3gMKPsFCUr7UAdMA==",
-          "requires": {
-            "ip": "1.1.5",
-            "is-valid-domain": "0.0.5"
-          }
-        }
+        "base64-url": "^2.2.0",
+        "epidemic-broadcast-trees": "^6.3.1",
+        "lossy-store": "^1.2.3",
+        "pull-stream": "^3.5.0",
+        "push-stream-to-pull-stream": "^1.0.0",
+        "ssb-ref": "^2.9.1"
       }
     },
     "ssb-embedded-chat": {
@@ -7850,7 +7019,7 @@
         "depject": "4.1.1",
         "depnest": "1.3.0",
         "hyperscript": "2.0.2",
-        "patchcore": "1.28.0",
+        "patchcore": "^1.23.4",
         "pull-scroll": "1.0.9",
         "pull-stream": "3.6.0"
       },
@@ -7860,7 +7029,7 @@
           "resolved": "https://registry.npmjs.org/html-element/-/html-element-2.2.0.tgz",
           "integrity": "sha1-w8H/iMJh23TQr2OR7vkMNG+QBzA=",
           "requires": {
-            "class-list": "0.1.1"
+            "class-list": "~0.1.1"
           }
         },
         "hyperscript": {
@@ -7869,8 +7038,8 @@
           "integrity": "sha1-ODnLpFVUvf4nu4HCFC0WhPgTWvU=",
           "requires": {
             "browser-split": "0.0.0",
-            "class-list": "0.1.1",
-            "html-element": "2.2.0"
+            "class-list": "~0.1.0",
+            "html-element": "^2.0.0"
           }
         },
         "pull-stream": {
@@ -7885,11 +7054,11 @@
       "resolved": "https://registry.npmjs.org/ssb-feed/-/ssb-feed-2.3.0.tgz",
       "integrity": "sha1-uE6OApeg9ZBMTPWiAvdroeB40Ec=",
       "requires": {
-        "cont": "1.0.3",
-        "monotonic-timestamp": "0.0.9",
-        "pull-stream": "3.6.8",
-        "ssb-keys": "7.0.16",
-        "ssb-ref": "2.8.0"
+        "cont": "~1.0.3",
+        "monotonic-timestamp": "~0.0.9",
+        "pull-stream": "^3.4.2",
+        "ssb-keys": "^7.0.0",
+        "ssb-ref": "^2.0.0"
       }
     },
     "ssb-friends": {
@@ -7897,13 +7066,13 @@
       "resolved": "https://registry.npmjs.org/ssb-friends/-/ssb-friends-2.4.0.tgz",
       "integrity": "sha1-DUDNlqEvIznJBkqK0dWnE+kcV64=",
       "requires": {
-        "flumeview-reduce": "1.3.9",
-        "graphreduce": "3.0.4",
+        "flumeview-reduce": "^1.3.0",
+        "graphreduce": "^3.0.3",
         "obv": "0.0.1",
-        "pull-cont": "0.1.1",
+        "pull-cont": "^0.1.1",
         "pull-flatmap": "0.0.1",
-        "pull-stream": "3.6.8",
-        "ssb-ref": "2.8.0"
+        "pull-stream": "^3.6.0",
+        "ssb-ref": "^2.7.1"
       }
     },
     "ssb-git": {
@@ -7916,23 +7085,23 @@
       "resolved": "https://registry.npmjs.org/ssb-git-repo/-/ssb-git-repo-2.8.3.tgz",
       "integrity": "sha512-7GVq5Ael/get+3Ot5exLdRWU8psSQNv/SkyO0KUhjoc4VfTdz8XuN1K195LKiyL/7u31A50KmkG9U9twb+1rGQ==",
       "requires": {
-        "hashlru": "2.2.0",
-        "kvgraph": "0.1.0",
-        "kvset": "1.0.0",
-        "multicb": "1.2.2",
-        "pull-box-stream": "1.0.13",
-        "pull-cache": "0.0.0",
-        "pull-cat": "1.1.11",
-        "pull-git-pack": "1.0.2",
-        "pull-git-pack-concat": "0.2.1",
-        "pull-git-repo": "1.2.1",
-        "pull-hash": "1.0.0",
-        "pull-paramap": "1.2.2",
-        "pull-stream": "3.6.8",
-        "ssb-git": "0.5.0",
-        "ssb-mentions": "0.1.2",
-        "ssb-pull-requests": "1.0.0",
-        "ssb-ref": "2.8.0"
+        "hashlru": "^2.1.0",
+        "kvgraph": "^0.1.0",
+        "kvset": "^1.0.0",
+        "multicb": "^1.2.1",
+        "pull-box-stream": "^1.0.12",
+        "pull-cache": "^0.0.0",
+        "pull-cat": "^1.1.11",
+        "pull-git-pack": "^1.0.0",
+        "pull-git-pack-concat": "^0.2.0",
+        "pull-git-repo": "^1.1.0",
+        "pull-hash": "^1.0.0",
+        "pull-paramap": "^1.2.1",
+        "pull-stream": "^3.4.5",
+        "ssb-git": "^0.5.0",
+        "ssb-mentions": "^0.1.0",
+        "ssb-pull-requests": "^1.0.0",
+        "ssb-ref": "^2.6.2"
       },
       "dependencies": {
         "ssb-marked": {
@@ -7945,8 +7114,8 @@
           "resolved": "https://registry.npmjs.org/ssb-mentions/-/ssb-mentions-0.1.2.tgz",
           "integrity": "sha1-0EQnCOOvXiRaevnBq9j4mrA8gMA=",
           "requires": {
-            "ssb-marked": "0.5.4",
-            "ssb-ref": "2.8.0"
+            "ssb-marked": "^0.5.4",
+            "ssb-ref": "^2.3.0"
           }
         }
       }
@@ -7956,9 +7125,9 @@
       "resolved": "https://registry.npmjs.org/ssb-horcrux/-/ssb-horcrux-1.0.0.tgz",
       "integrity": "sha512-myL9cYy/3C67g09ZWKaLo7+NWDF1ffP5VXJavlr5eOfc207DexKwh+eqTBs0y+98i8erHB2gwE8Uvb4quUmcBQ==",
       "requires": {
-        "depnest": "1.3.0",
-        "mutant": "3.22.1",
-        "secrets.js": "0.1.8"
+        "depnest": "^1.3.0",
+        "mutant": "^3.18.0",
+        "secrets.js": "^0.1.8"
       }
     },
     "ssb-issues": {
@@ -7966,12 +7135,12 @@
       "resolved": "https://registry.npmjs.org/ssb-issues/-/ssb-issues-1.0.0.tgz",
       "integrity": "sha1-noV9Fw3/FSxTonPrkASgqRShBuU=",
       "requires": {
-        "asyncmemo": "1.0.0",
-        "multicb": "1.2.2",
-        "pull-paramap": "1.2.2",
-        "pull-stream": "3.6.8",
-        "ssb-msgs": "5.2.0",
-        "ssb-ref": "2.8.0"
+        "asyncmemo": "^1.0.0",
+        "multicb": "^1.2.1",
+        "pull-paramap": "^1.1.2",
+        "pull-stream": "^3.2.0",
+        "ssb-msgs": "^5.2.0",
+        "ssb-ref": "^2.3.0"
       }
     },
     "ssb-keys": {
@@ -7979,9 +7148,9 @@
       "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.0.16.tgz",
       "integrity": "sha512-EhLkRzgF7YaRc47L8YZb+TcxEXZy9DPWCF+vCt5nSNm8Oj+Pz8pBVSOlrLKZVbcAKFjIJhqY32oTjknu3E1KVQ==",
       "requires": {
-        "chloride": "2.2.8",
-        "mkdirp": "0.5.1",
-        "private-box": "0.2.1"
+        "chloride": "^2.2.8",
+        "mkdirp": "~0.5.0",
+        "private-box": "^0.2.1"
       }
     },
     "ssb-links": {
@@ -7989,10 +7158,10 @@
       "resolved": "https://registry.npmjs.org/ssb-links/-/ssb-links-3.0.3.tgz",
       "integrity": "sha512-x09ShIMjwvdZI7aDZm8kc1v5YCGZa9ulCOoxrf/RYJ98s5gbTfO9CBCzeMBAeQ5kRwSuKjiOxJHdeEBkj4Y6hw==",
       "requires": {
-        "flumeview-query": "6.2.0",
-        "map-filter-reduce": "2.2.1",
-        "pull-stream": "3.6.8",
-        "ssb-msgs": "5.2.0"
+        "flumeview-query": "^6.0.0",
+        "map-filter-reduce": "^2.0.0",
+        "pull-stream": "^3.1.0",
+        "ssb-msgs": "^5.2.0"
       }
     },
     "ssb-markdown": {
@@ -8000,32 +7169,25 @@
       "resolved": "https://registry.npmjs.org/ssb-markdown/-/ssb-markdown-3.6.0.tgz",
       "integrity": "sha512-WaI/s6Zbq9EBAE9CD2OnPMn1U7Wce3HBK3EZN2qfnjIEkirL/oj8Wz92sBYyyV+tae1aJJRTV7/PFbT5YfNk+g==",
       "requires": {
-        "emoji-named-characters": "1.0.2",
-        "ssb-marked": "0.7.4",
-        "ssb-msgs": "5.2.0",
-        "ssb-ref": "2.8.0"
-      },
-      "dependencies": {
-        "ssb-marked": {
-          "version": "0.7.4",
-          "resolved": "https://registry.npmjs.org/ssb-marked/-/ssb-marked-0.7.4.tgz",
-          "integrity": "sha1-MXFPFlSFMcmaA6JOIsfh67vOeHU="
-        }
+        "emoji-named-characters": "^1.0.2",
+        "ssb-marked": "^0.7.3",
+        "ssb-msgs": "^5.2.0",
+        "ssb-ref": "^2.3.0"
       }
     },
     "ssb-marked": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/ssb-marked/-/ssb-marked-0.7.2.tgz",
-      "integrity": "sha1-Fg4kETeCqcpegGByqnpl58hl2/I="
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/ssb-marked/-/ssb-marked-0.7.4.tgz",
+      "integrity": "sha1-MXFPFlSFMcmaA6JOIsfh67vOeHU="
     },
     "ssb-meme": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/ssb-meme/-/ssb-meme-1.0.4.tgz",
       "integrity": "sha512-r4JAfdCY7tnRzMQNETdWfcm54FOe6bJMbpanp+9dQA76daLu1Jg3EijQ4jNtnDtv1WDMq1XcDTQyEtzVICrKBg==",
       "requires": {
-        "flumeview-search": "1.0.4",
-        "is-my-json-valid": "2.17.2",
-        "ssb-ref": "2.11.1"
+        "flumeview-search": "^1.0.3",
+        "is-my-json-valid": "^2.17.2",
+        "ssb-ref": "^2.11.1"
       },
       "dependencies": {
         "is-my-json-valid": {
@@ -8033,20 +7195,11 @@
           "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
           "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
           "requires": {
-            "generate-function": "2.0.0",
-            "generate-object-property": "1.2.0",
-            "is-my-ip-valid": "1.0.0",
-            "jsonpointer": "4.0.1",
-            "xtend": "4.0.1"
-          }
-        },
-        "ssb-ref": {
-          "version": "2.11.1",
-          "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.11.1.tgz",
-          "integrity": "sha512-K3L9hJ1v0HrH8abtEKiBkdeabHVaws+CS81mZqUfhR84i0dlYhiIIDwqeLxUj/1mLcsZPF3gMKPsFCUr7UAdMA==",
-          "requires": {
-            "ip": "1.1.5",
-            "is-valid-domain": "0.0.5"
+            "generate-function": "^2.0.0",
+            "generate-object-property": "^1.1.0",
+            "is-my-ip-valid": "^1.0.0",
+            "jsonpointer": "^4.0.0",
+            "xtend": "^4.0.0"
           }
         }
       }
@@ -8056,19 +7209,8 @@
       "resolved": "https://registry.npmjs.org/ssb-mentions/-/ssb-mentions-0.5.0.tgz",
       "integrity": "sha512-tXFr8CSNPKwCkRftm8Z0H5mXhfHLNhwNgo7PdR8GobxCSSoaHXfxsGbAJVKDl/kCkgL92nPidS3SlsFqtjFE7Q==",
       "requires": {
-        "ssb-marked": "0.7.2",
-        "ssb-ref": "2.11.1"
-      },
-      "dependencies": {
-        "ssb-ref": {
-          "version": "2.11.1",
-          "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.11.1.tgz",
-          "integrity": "sha512-K3L9hJ1v0HrH8abtEKiBkdeabHVaws+CS81mZqUfhR84i0dlYhiIIDwqeLxUj/1mLcsZPF3gMKPsFCUr7UAdMA==",
-          "requires": {
-            "ip": "1.1.5",
-            "is-valid-domain": "0.0.5"
-          }
-        }
+        "ssb-marked": "^0.7.0",
+        "ssb-ref": "^2.11.0"
       }
     },
     "ssb-msg-content": {
@@ -8081,10 +7223,10 @@
       "resolved": "https://registry.npmjs.org/ssb-msg-schemas/-/ssb-msg-schemas-6.3.0.tgz",
       "integrity": "sha1-I8EkQ9TloMSBd0NjjuDKk85t3IU=",
       "requires": {
-        "is-my-json-valid": "2.16.1",
-        "pull-stream": "2.27.0",
-        "ssb-msgs": "5.2.0",
-        "ssb-ref": "2.8.0"
+        "is-my-json-valid": "^2.16.0",
+        "pull-stream": "~2.27.0",
+        "ssb-msgs": "^5.0.0",
+        "ssb-ref": "^2.7.0"
       },
       "dependencies": {
         "pull-stream": {
@@ -8092,7 +7234,7 @@
           "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-2.27.0.tgz",
           "integrity": "sha1-/fDrkQzcQEHWWVbAC+4w270AoGg=",
           "requires": {
-            "pull-core": "1.1.0"
+            "pull-core": "~1.1.0"
           }
         }
       }
@@ -8102,7 +7244,7 @@
       "resolved": "https://registry.npmjs.org/ssb-msgs/-/ssb-msgs-5.2.0.tgz",
       "integrity": "sha1-xoHaXNcMV0ySLcpPA8UhU4E1wkM=",
       "requires": {
-        "ssb-ref": "2.8.0"
+        "ssb-ref": "^2.0.0"
       }
     },
     "ssb-mutual": {
@@ -8110,11 +7252,11 @@
       "resolved": "https://registry.npmjs.org/ssb-mutual/-/ssb-mutual-0.1.0.tgz",
       "integrity": "sha1-4i+ieaJCItg1V0dd1BU8YqUO4qA=",
       "requires": {
-        "big.js": "3.2.0",
-        "pull-many": "1.0.8",
-        "pull-paramap": "1.2.2",
-        "pull-stream": "3.6.8",
-        "ssb-ref": "2.8.0"
+        "big.js": "^3.1.3",
+        "pull-many": "^1.0.8",
+        "pull-paramap": "^1.2.1",
+        "pull-stream": "^3.5.0",
+        "ssb-ref": "^2.6.2"
       }
     },
     "ssb-ooo-about": {
@@ -8122,10 +7264,10 @@
       "resolved": "https://registry.npmjs.org/ssb-ooo-about/-/ssb-ooo-about-1.0.0.tgz",
       "integrity": "sha512-Bn99P10Glh5KtPmNqwQocQq1/McI4R4zc9vnMSaSRRlLSuEXNPHcJ45Uda519Xp2C4fS8dF4pML6ljZFN0ns0Q==",
       "requires": {
-        "array-unique": "0.3.2",
-        "bluebird": "3.5.1",
-        "pull-stream": "3.6.8",
-        "ssb-client": "4.5.7"
+        "array-unique": "^0.3.2",
+        "bluebird": "^3.5.1",
+        "pull-stream": "^3.6.2",
+        "ssb-client": "^4.5.7"
       },
       "dependencies": {
         "array-unique": {
@@ -8140,12 +7282,12 @@
       "resolved": "https://registry.npmjs.org/ssb-poll-schema/-/ssb-poll-schema-1.6.1.tgz",
       "integrity": "sha512-89MItu5+owPlHMzjQsLhjb4p13/ll0xHKVYZn2gHPmmnpeLJPLNw4NfZTquje7sLCaV44fvLJ5kWoj825fN+4g==",
       "requires": {
-        "depject": "4.1.1",
-        "depnest": "1.3.0",
-        "is-my-json-valid": "2.17.2",
-        "lodash.clonedeep": "4.5.0",
-        "ssb-msg-content": "1.0.1",
-        "ssb-ref": "2.11.1"
+        "depject": "^4.1.1",
+        "depnest": "^1.3.0",
+        "is-my-json-valid": "^2.17.2",
+        "lodash.clonedeep": "^4.5.0",
+        "ssb-msg-content": "^1.0.1",
+        "ssb-ref": "^2.9.1"
       },
       "dependencies": {
         "is-my-json-valid": {
@@ -8153,41 +7295,25 @@
           "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
           "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
           "requires": {
-            "generate-function": "2.0.0",
-            "generate-object-property": "1.2.0",
-            "is-my-ip-valid": "1.0.0",
-            "jsonpointer": "4.0.1",
-            "xtend": "4.0.1"
-          }
-        },
-        "ssb-ref": {
-          "version": "2.11.1",
-          "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.11.1.tgz",
-          "integrity": "sha512-K3L9hJ1v0HrH8abtEKiBkdeabHVaws+CS81mZqUfhR84i0dlYhiIIDwqeLxUj/1mLcsZPF3gMKPsFCUr7UAdMA==",
-          "requires": {
-            "ip": "1.1.5",
-            "is-valid-domain": "0.0.5"
+            "generate-function": "^2.0.0",
+            "generate-object-property": "^1.1.0",
+            "is-my-ip-valid": "^1.0.0",
+            "jsonpointer": "^4.0.0",
+            "xtend": "^4.0.0"
           }
         }
       }
     },
     "ssb-private": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/ssb-private/-/ssb-private-0.2.2.tgz",
-      "integrity": "sha512-/5ztI3zCSWbh4aW+/PkelfHfwR7Mjwk+7libgJEpwKOIM1gWCV0VvGXAGQWLKX7qdf6a8xTQdRHSIL/MnRJu7w==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/ssb-private/-/ssb-private-0.2.3.tgz",
+      "integrity": "sha512-SiLBKOB1hxkrohzOrRWURlzj6HvPFvr9LLd5P5I5C5KU/RtaWe79nYuFgjUFJFnjWw7X4szCy32/EZMihV1l/Q==",
       "requires": {
-        "base64-url": "2.2.0",
-        "explain-error": "1.0.4",
-        "flumeview-query": "6.2.0",
-        "pull-stream": "3.6.8",
-        "ssb-keys": "7.0.16"
-      },
-      "dependencies": {
-        "base64-url": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-2.2.0.tgz",
-          "integrity": "sha512-Y4qHHAE+rWjmAFPQmHPiiD+hWwM/XvuFLlP6kVxlwZJK7rjiE2uIQR9tZ37iEr1E6iCj9799yxMAmiXzITb3lQ=="
-        }
+        "base64-url": "^2.2.0",
+        "explain-error": "^1.0.4",
+        "flumeview-query": "^6.1.0",
+        "pull-stream": "^3.6.7",
+        "ssb-keys": "^7.0.14"
       }
     },
     "ssb-pull-requests": {
@@ -8195,11 +7321,11 @@
       "resolved": "https://registry.npmjs.org/ssb-pull-requests/-/ssb-pull-requests-1.0.0.tgz",
       "integrity": "sha1-39MM1Q7s2FRr1Kp/BufI9QHAgRg=",
       "requires": {
-        "asyncmemo": "1.0.0",
-        "pull-paramap": "1.2.2",
-        "pull-stream": "3.6.8",
-        "ssb-issues": "1.0.0",
-        "ssb-ref": "2.8.0"
+        "asyncmemo": "^1.0.0",
+        "pull-paramap": "^1.1.2",
+        "pull-stream": "^3.2.0",
+        "ssb-issues": "^1.0.0",
+        "ssb-ref": "^2.3.0"
       }
     },
     "ssb-query": {
@@ -8207,18 +7333,18 @@
       "resolved": "https://registry.npmjs.org/ssb-query/-/ssb-query-2.1.0.tgz",
       "integrity": "sha512-4QWvjSrSIon9qyhPHrqOeA/dp6NR7b11BtXKhJg/Di2r7/nBLGAj2RzUonfTfs3LlPHZdFWXowhhJREUAmUZug==",
       "requires": {
-        "explain-error": "1.0.4",
-        "flumeview-query": "6.2.0",
-        "pull-stream": "3.6.8"
+        "explain-error": "^1.0.1",
+        "flumeview-query": "^6.0.0",
+        "pull-stream": "^3.6.2"
       }
     },
     "ssb-ref": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.8.0.tgz",
-      "integrity": "sha1-d8+c6oaROlu3kW4ma7ceavQdb24=",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.11.1.tgz",
+      "integrity": "sha512-K3L9hJ1v0HrH8abtEKiBkdeabHVaws+CS81mZqUfhR84i0dlYhiIIDwqeLxUj/1mLcsZPF3gMKPsFCUr7UAdMA==",
       "requires": {
-        "ip": "1.1.5",
-        "is-valid-domain": "0.0.5"
+        "ip": "^1.1.3",
+        "is-valid-domain": "~0.0.1"
       }
     },
     "ssb-search": {
@@ -8226,10 +7352,10 @@
       "resolved": "https://registry.npmjs.org/ssb-search/-/ssb-search-1.1.2.tgz",
       "integrity": "sha512-k7CCfdugGYvNMZekGJXcCYuCdf7MEP+bBZr+AsZO5KqaNb4K9CuP6W1wGoKH6vkparhaCKc85jO46EbWsEoVDQ==",
       "requires": {
-        "flumeview-search": "1.0.4",
-        "pull-cont": "0.1.1",
-        "pull-stream": "3.6.8",
-        "ssb-msgs": "5.2.0"
+        "flumeview-search": "^1.0.0",
+        "pull-cont": "^0.1.1",
+        "pull-stream": "^3.6.7",
+        "ssb-msgs": "^5.2.0"
       }
     },
     "ssb-sort": {
@@ -8237,7 +7363,7 @@
       "resolved": "https://registry.npmjs.org/ssb-sort/-/ssb-sort-1.1.0.tgz",
       "integrity": "sha512-UGn0GXkcpno7rNYWJhywmtKDnbhAHT3Nj++tMFP0pJ5shKL8SiipGYnjpZ8nVW185HNsEdsS06yJPD4o3hQyDQ==",
       "requires": {
-        "ssb-ref": "2.8.0"
+        "ssb-ref": "^2.3.0"
       }
     },
     "ssb-validate": {
@@ -8245,7 +7371,7 @@
       "resolved": "https://registry.npmjs.org/ssb-validate/-/ssb-validate-3.0.10.tgz",
       "integrity": "sha512-9wJE1i+4vW/F/TYQQl15BVoiZb9kaqIRBhl2I/TXyhjngfx/yBzXFAuiXhaiDfqJ3YnUXzY4JMUSx0gIvpePnQ==",
       "requires": {
-        "ssb-ref": "2.8.0"
+        "ssb-ref": "^2.6.2"
       }
     },
     "ssb-ws": {
@@ -8253,13 +7379,13 @@
       "resolved": "https://registry.npmjs.org/ssb-ws/-/ssb-ws-2.1.1.tgz",
       "integrity": "sha512-1fK/jXI6lKZadRJDr49t+6yMmWynp6PFrADs3Whmy8IslnYGl83ujhlpRIBvCn1EuVHjV7yLsIiJ8a0X2Kg0DQ==",
       "requires": {
-        "emoji-server": "1.0.0",
-        "multiblob-http": "0.4.2",
-        "multiserver": "1.10.0",
-        "muxrpc": "6.4.0",
-        "pull-box-stream": "1.0.13",
-        "ssb-ref": "2.8.0",
-        "stack": "0.1.0"
+        "emoji-server": "^1.0.0",
+        "multiblob-http": "^0.4.1",
+        "multiserver": "^1.2.0",
+        "muxrpc": "^6.3.3",
+        "pull-box-stream": "^1.0.13",
+        "ssb-ref": "^2.3.0",
+        "stack": "^0.1.0"
       }
     },
     "sshpk": {
@@ -8268,15 +7394,15 @@
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "dev": true,
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.2",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       }
     },
     "stack": {
@@ -8290,13 +7416,13 @@
       "integrity": "sha1-Y1Eyvnv7VnwpIQBfMPnjUOR1Kq0=",
       "dev": true,
       "requires": {
-        "eslint": "3.10.2",
+        "eslint": "~3.10.2",
         "eslint-config-standard": "6.2.1",
         "eslint-config-standard-jsx": "3.2.0",
-        "eslint-plugin-promise": "3.4.2",
-        "eslint-plugin-react": "6.7.1",
-        "eslint-plugin-standard": "2.0.1",
-        "standard-engine": "5.2.0"
+        "eslint-plugin-promise": "~3.4.0",
+        "eslint-plugin-react": "~6.7.1",
+        "eslint-plugin-standard": "~2.0.1",
+        "standard-engine": "~5.2.0"
       }
     },
     "standard-engine": {
@@ -8305,12 +7431,12 @@
       "integrity": "sha1-QAZgrlrM6K/U22D/IhSpGQrXkKM=",
       "dev": true,
       "requires": {
-        "deglob": "2.1.0",
-        "find-root": "1.1.0",
-        "get-stdin": "5.0.1",
-        "home-or-tmp": "2.0.0",
-        "minimist": "1.2.0",
-        "pkg-config": "1.1.1"
+        "deglob": "^2.0.0",
+        "find-root": "^1.0.0",
+        "get-stdin": "^5.0.1",
+        "home-or-tmp": "^2.0.0",
+        "minimist": "^1.1.0",
+        "pkg-config": "^1.0.1"
       },
       "dependencies": {
         "get-stdin": {
@@ -8332,7 +7458,7 @@
       "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-0.2.4.tgz",
       "integrity": "sha1-t9NNg4k3uWn5ZBygfUj47eJj6ns=",
       "requires": {
-        "escodegen": "0.0.28"
+        "escodegen": "~0.0.24"
       },
       "dependencies": {
         "escodegen": {
@@ -8340,9 +7466,9 @@
           "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
           "integrity": "sha1-Dk/xcV8yh3XWyrUaxEpAbNer/9M=",
           "requires": {
-            "esprima": "1.0.4",
-            "estraverse": "1.3.2",
-            "source-map": "0.1.43"
+            "esprima": "~1.0.2",
+            "estraverse": "~1.3.0",
+            "source-map": ">= 0.1.2"
           }
         },
         "esprima": {
@@ -8362,17 +7488,17 @@
       "resolved": "https://registry.npmjs.org/static-module/-/static-module-1.5.0.tgz",
       "integrity": "sha1-J9qYg8QajNCSNvhC8MHrxu32PYY=",
       "requires": {
-        "concat-stream": "1.6.0",
-        "duplexer2": "0.0.2",
-        "escodegen": "1.3.3",
-        "falafel": "2.1.0",
-        "has": "1.0.1",
-        "object-inspect": "0.4.0",
-        "quote-stream": "0.0.0",
-        "readable-stream": "1.0.34",
-        "shallow-copy": "0.0.1",
-        "static-eval": "0.2.4",
-        "through2": "0.4.2"
+        "concat-stream": "~1.6.0",
+        "duplexer2": "~0.0.2",
+        "escodegen": "~1.3.2",
+        "falafel": "^2.1.0",
+        "has": "^1.0.0",
+        "object-inspect": "~0.4.0",
+        "quote-stream": "~0.0.0",
+        "readable-stream": "~1.0.27-1",
+        "shallow-copy": "~0.0.1",
+        "static-eval": "~0.2.0",
+        "through2": "~0.4.1"
       },
       "dependencies": {
         "isarray": {
@@ -8385,10 +7511,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -8408,8 +7534,8 @@
       "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.2.tgz",
       "integrity": "sha1-dXYJrhzr0zx0MtSvvjH/eGULnd4=",
       "requires": {
-        "looper": "3.0.0",
-        "pull-stream": "3.6.8"
+        "looper": "^3.0.0",
+        "pull-stream": "^3.2.3"
       },
       "dependencies": {
         "looper": {
@@ -8429,9 +7555,9 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "string.prototype.trim": {
@@ -8439,9 +7565,9 @@
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
       "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.12.0",
-        "function-bind": "1.1.1"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.0",
+        "function-bind": "^1.0.2"
       }
     },
     "string_decoder": {
@@ -8449,18 +7575,18 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.1.0"
       }
     },
     "stringify-entities": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.1.tgz",
-      "integrity": "sha1-sVDsLXKsTBtfMktR+2soyc3/BYw=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
+      "integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
       "requires": {
-        "character-entities-html4": "1.1.1",
-        "character-entities-legacy": "1.1.1",
-        "is-alphanumerical": "1.0.1",
-        "is-hexadecimal": "1.0.1"
+        "character-entities-html4": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
       }
     },
     "stringify-object": {
@@ -8468,8 +7594,8 @@
       "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-2.4.0.tgz",
       "integrity": "sha1-xi0RAj6yH+LZsIe+A5om3zsioJ0=",
       "requires": {
-        "is-plain-obj": "1.1.0",
-        "is-regexp": "1.0.0"
+        "is-plain-obj": "^1.0.0",
+        "is-regexp": "^1.0.0"
       }
     },
     "strip-ansi": {
@@ -8477,7 +7603,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -8486,7 +7612,7 @@
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
-        "is-utf8": "0.2.1"
+        "is-utf8": "^0.2.0"
       }
     },
     "strip-indent": {
@@ -8495,7 +7621,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1"
+        "get-stdin": "^4.0.1"
       }
     },
     "strip-json-comments": {
@@ -8504,12 +7630,12 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "style-resolve": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/style-resolve/-/style-resolve-1.0.1.tgz",
-      "integrity": "sha1-LSBnyUTV+39VPKdcTnlH30N5b64=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/style-resolve/-/style-resolve-1.1.0.tgz",
+      "integrity": "sha512-TCt/cEeLTrnprw4uGaUyjHiQOLXPBdbr16dNEsPEI6DjEcvk408pTtYQ88M4Wv930zOTe/Q0fcvquSOTEeb5OQ==",
       "requires": {
-        "resolve": "1.5.0",
-        "xtend": "4.0.1"
+        "resolve": "^1.1.7",
+        "xtend": "^4.0.1"
       }
     },
     "subarg": {
@@ -8518,7 +7644,7 @@
       "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
       "dev": true,
       "requires": {
-        "minimist": "1.2.0"
+        "minimist": "^1.1.0"
       },
       "dependencies": {
         "minimist": {
@@ -8534,8 +7660,8 @@
       "resolved": "https://registry.npmjs.org/suggest-box/-/suggest-box-2.2.3.tgz",
       "integrity": "sha1-wGvw4wUXUx/fdH/+DG/15Sv/DkQ=",
       "requires": {
-        "hyperscript": "1.4.7",
-        "textarea-caret-position": "0.1.1"
+        "hyperscript": "~1.4.2",
+        "textarea-caret-position": "^0.1.1"
       }
     },
     "sumchecker": {
@@ -8544,8 +7670,8 @@
       "integrity": "sha1-ebs7RFbdBPGOvbwNcDodHa7FEF0=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "es6-promise": "4.2.4"
+        "debug": "^2.2.0",
+        "es6-promise": "^4.0.5"
       }
     },
     "supports-color": {
@@ -8559,12 +7685,12 @@
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "requires": {
-        "ajv": "4.11.8",
-        "ajv-keywords": "1.5.1",
-        "chalk": "1.1.3",
-        "lodash": "4.17.10",
+        "ajv": "^4.7.0",
+        "ajv-keywords": "^1.0.0",
+        "chalk": "^1.1.1",
+        "lodash": "^4.0.0",
         "slice-ansi": "0.0.4",
-        "string-width": "2.1.1"
+        "string-width": "^2.0.0"
       },
       "dependencies": {
         "ajv": {
@@ -8573,8 +7699,8 @@
           "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
           "dev": true,
           "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
+            "co": "^4.6.0",
+            "json-stable-stringify": "^1.0.1"
           }
         },
         "ansi-regex": {
@@ -8601,8 +7727,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -8611,7 +7737,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -8621,29 +7747,21 @@
       "resolved": "https://registry.npmjs.org/tape/-/tape-4.9.1.tgz",
       "integrity": "sha512-6fKIXknLpoe/Jp4rzHKFPpJUHDHDqn8jus99IfPnHIjyz78HYlefTGD3b5EkbQzuLfaEvmfPK3IolLgq2xT3kw==",
       "requires": {
-        "deep-equal": "1.0.1",
-        "defined": "1.0.0",
-        "for-each": "0.3.3",
-        "function-bind": "1.1.1",
-        "glob": "7.1.2",
-        "has": "1.0.3",
-        "inherits": "2.0.3",
-        "minimist": "1.2.0",
-        "object-inspect": "1.6.0",
-        "resolve": "1.7.1",
-        "resumer": "0.0.0",
-        "string.prototype.trim": "1.1.2",
-        "through": "2.3.8"
+        "deep-equal": "~1.0.1",
+        "defined": "~1.0.0",
+        "for-each": "~0.3.3",
+        "function-bind": "~1.1.1",
+        "glob": "~7.1.2",
+        "has": "~1.0.3",
+        "inherits": "~2.0.3",
+        "minimist": "~1.2.0",
+        "object-inspect": "~1.6.0",
+        "resolve": "~1.7.1",
+        "resumer": "~0.0.0",
+        "string.prototype.trim": "~1.1.2",
+        "through": "~2.3.8"
       },
       "dependencies": {
-        "has": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-          "requires": {
-            "function-bind": "1.1.1"
-          }
-        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -8659,7 +7777,7 @@
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
           "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
           "requires": {
-            "path-parse": "1.0.5"
+            "path-parse": "^1.0.5"
           }
         },
         "through": {
@@ -8670,35 +7788,28 @@
       }
     },
     "tar-fs": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.0.tgz",
-      "integrity": "sha512-I9rb6v7mjWLtOfCau9eH5L7sLJyU2BnxtEZRQ5Mt+eRKmf1F0ohXmT/Jc3fr52kDvjJ/HV5MH3soQfPL5bQ0Yg==",
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
+      "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
       "requires": {
-        "chownr": "1.0.1",
-        "mkdirp": "0.5.1",
-        "pump": "1.0.3",
-        "tar-stream": "1.5.5"
+        "chownr": "^1.0.1",
+        "mkdirp": "^0.5.1",
+        "pump": "^1.0.0",
+        "tar-stream": "^1.1.2"
       }
     },
     "tar-stream": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
-      "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
+      "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
       "requires": {
-        "bl": "1.2.1",
-        "end-of-stream": "1.4.0",
-        "readable-stream": "2.3.3",
-        "xtend": "4.0.1"
-      },
-      "dependencies": {
-        "bl": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
-          "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
-          "requires": {
-            "readable-stream": "2.3.3"
-          }
-        }
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.1.0",
+        "end-of-stream": "^1.0.0",
+        "fs-constants": "^1.0.0",
+        "readable-stream": "^2.3.0",
+        "to-buffer": "^1.1.0",
+        "xtend": "^4.0.0"
       }
     },
     "text-node-searcher": {
@@ -8732,8 +7843,8 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
       "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
       "requires": {
-        "readable-stream": "1.0.34",
-        "xtend": "2.1.2"
+        "readable-stream": "~1.0.17",
+        "xtend": "~2.1.1"
       },
       "dependencies": {
         "isarray": {
@@ -8751,10 +7862,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -8767,7 +7878,7 @@
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
           "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
           "requires": {
-            "object-keys": "0.4.0"
+            "object-keys": "~0.4.0"
           }
         }
       }
@@ -8776,6 +7887,11 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/tiny-worker/-/tiny-worker-2.1.1.tgz",
       "integrity": "sha1-BUbxQ35Dud4lPvqtI1BHZ31zVls="
+    },
+    "to-buffer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
     },
     "to-fast-properties": {
       "version": "1.0.3",
@@ -8787,7 +7903,7 @@
       "resolved": "https://registry.npmjs.org/to-vfile/-/to-vfile-1.0.0.tgz",
       "integrity": "sha1-iN7+zUOtsu9ZhiXw49WffzQpQbo=",
       "requires": {
-        "vfile": "1.4.0"
+        "vfile": "^1.0.0"
       }
     },
     "tough-cookie": {
@@ -8796,7 +7912,7 @@
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "dev": true,
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "trim": {
@@ -8805,9 +7921,9 @@
       "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
     },
     "trim-lines": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-1.1.0.tgz",
-      "integrity": "sha1-mSbQPt4Tuhj31CIiYx+wTHn/Jv4="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-1.1.1.tgz",
+      "integrity": "sha512-X+eloHbgJGxczUk1WSjIvn7aC9oN3jVE3rQfRVKcgpavi3jxtCn0VVKtjOBj64Yop96UYn/ujJRpTbCdAF1vyg=="
     },
     "trim-newlines": {
       "version": "1.0.0",
@@ -8821,9 +7937,9 @@
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "trim-trailing-lines": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.0.tgz",
-      "integrity": "sha1-eu+7eAjfnWafbaLkOMrIxGradoQ="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.1.tgz",
+      "integrity": "sha512-bWLv9BbWbbd7mlqqs2oQYnLD/U/ZqeJeJwbO0FG2zA1aTq+HTvxfHNKFa/HGCVyJpDiioUYaBhfiT6rgk+l4mg=="
     },
     "tryit": {
       "version": "1.0.3",
@@ -8836,7 +7952,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -8849,7 +7965,7 @@
       "resolved": "https://registry.npmjs.org/tweetnacl-auth/-/tweetnacl-auth-0.3.1.tgz",
       "integrity": "sha1-t1vC3xVkm7hOi5qjwGacbEvODSU=",
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "0.x.x"
       }
     },
     "type-check": {
@@ -8858,7 +7974,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "typedarray": {
@@ -8871,7 +7987,7 @@
       "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
       "integrity": "sha1-EGeTZUCvl5N8xdz5kiSG6fooRlE=",
       "requires": {
-        "typewise-core": "1.2.0"
+        "typewise-core": "^1.2.0"
       }
     },
     "typewise-core": {
@@ -8895,12 +8011,12 @@
       "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
     },
     "unherit": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.0.tgz",
-      "integrity": "sha1-a5qu379z3xdWrZ4xbdmBiFhAzX0=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.1.tgz",
+      "integrity": "sha512-+XZuV691Cn4zHsK0vkKYwBEwB74T3IZIcxrgn2E4rKwTfFyI1zCh7X7grwh9Re08fdPlarIdyWgI8aVB3F5A5g==",
       "requires": {
-        "inherits": "2.0.3",
-        "xtend": "4.0.1"
+        "inherits": "^2.0.1",
+        "xtend": "^4.0.1"
       }
     },
     "unified": {
@@ -8908,12 +8024,12 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-2.1.4.tgz",
       "integrity": "sha1-FLxs1A2Y//91tAVQa62HPsu6w7o=",
       "requires": {
-        "attach-ware": "1.1.1",
-        "bail": "1.0.2",
-        "extend": "3.0.1",
-        "unherit": "1.1.0",
-        "vfile": "1.4.0",
-        "ware": "1.3.0"
+        "attach-ware": "^1.0.0",
+        "bail": "^1.0.0",
+        "extend": "^3.0.0",
+        "unherit": "^1.0.4",
+        "vfile": "^1.0.0",
+        "ware": "^1.3.0"
       }
     },
     "uniq": {
@@ -8923,16 +8039,24 @@
       "dev": true
     },
     "unist-util-is": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.1.tgz",
-      "integrity": "sha1-DDEmKeP5YMZukx6BLT2A53AQlHs="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.2.tgz",
+      "integrity": "sha512-YkXBK/H9raAmG7KXck+UUpnKiNmUdB+aBGrknfQ4EreE1banuzrKABx3jP6Z5Z3fMSPMQQmeXBlKpCbMwBkxVw=="
     },
     "unist-util-visit": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.2.0.tgz",
-      "integrity": "sha512-lI+jyPlDztHZ2CJhUchcRMQ7MNc0yASgYFxwRTxs0EZ+9HbYFBLVGDJ2FchTBy+pra0O1LVEn0Wkgf19mDVDzw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.0.tgz",
+      "integrity": "sha512-FiGu34ziNsZA3ZUteZxSFaczIjGmksfSgdKqBfOejrrfzyUy5b7YrlzT1Bcvi+djkYDituJDy2XB7tGTeBieKw==",
       "requires": {
-        "unist-util-is": "2.1.1"
+        "unist-util-visit-parents": "^2.0.0"
+      }
+    },
+    "unist-util-visit-parents": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.0.1.tgz",
+      "integrity": "sha512-6B0UTiMfdWql4cQ03gDTCSns+64Zkfo2OCbK31Ov0uMizEz+CJeAp0cgZVb5Fhmcd7Bct2iRNywejT0orpbqUA==",
+      "requires": {
+        "unist-util-is": "^2.1.2"
       }
     },
     "untildify": {
@@ -8940,7 +8064,7 @@
       "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
       "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
       "requires": {
-        "os-homedir": "1.0.2"
+        "os-homedir": "^1.0.0"
       }
     },
     "urify": {
@@ -8948,12 +8072,12 @@
       "resolved": "https://registry.npmjs.org/urify/-/urify-2.1.0.tgz",
       "integrity": "sha1-c0H2yhAmRx1yriMPK+q0Rb+ODwc=",
       "requires": {
-        "from2-string": "1.1.0",
-        "mime": "1.5.0",
-        "quote-stream": "1.0.2",
-        "readable-stream": "2.3.3",
-        "resolve": "1.5.0",
-        "static-module": "1.5.0"
+        "from2-string": "^1.1.0",
+        "mime": "^1.3.4",
+        "quote-stream": "^1.0.2",
+        "readable-stream": "^2.0.5",
+        "resolve": "^1.1.7",
+        "static-module": "^1.3.0"
       },
       "dependencies": {
         "minimist": {
@@ -8967,8 +8091,8 @@
           "integrity": "sha1-hJY/jJwmuULhU/7rU6rnRlK34LI=",
           "requires": {
             "buffer-equal": "0.0.1",
-            "minimist": "1.2.0",
-            "through2": "2.0.3"
+            "minimist": "^1.1.3",
+            "through2": "^2.0.0"
           }
         },
         "through2": {
@@ -8976,8 +8100,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "requires": {
-            "readable-stream": "2.3.3",
-            "xtend": "4.0.1"
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -8987,7 +8111,7 @@
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
       "requires": {
-        "os-homedir": "1.0.2"
+        "os-homedir": "^1.0.0"
       }
     },
     "util-deprecate": {
@@ -9002,13 +8126,13 @@
       "dev": true
     },
     "validate-npm-package-license": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
-      "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
-        "spdx-correct": "3.0.0",
-        "spdx-expression-parse": "3.0.0"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "verror": {
@@ -9017,9 +8141,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "vfile": {
@@ -9032,7 +8156,7 @@
       "resolved": "https://registry.npmjs.org/vfile-find-down/-/vfile-find-down-1.0.0.tgz",
       "integrity": "sha1-hKTWbQNRP2FAqE4Hdu8ISNTwrZU=",
       "requires": {
-        "to-vfile": "1.0.0"
+        "to-vfile": "^1.0.0"
       }
     },
     "vfile-find-up": {
@@ -9040,7 +8164,7 @@
       "resolved": "https://registry.npmjs.org/vfile-find-up/-/vfile-find-up-1.0.0.tgz",
       "integrity": "sha1-VgTab+RTs0NQY3mE61/kkJ4oA5A=",
       "requires": {
-        "to-vfile": "1.0.0"
+        "to-vfile": "^1.0.0"
       }
     },
     "vfile-reporter": {
@@ -9048,13 +8172,13 @@
       "resolved": "https://registry.npmjs.org/vfile-reporter/-/vfile-reporter-1.5.0.tgz",
       "integrity": "sha1-IacAm/5V4k34/0Mqpb9vbvp05Bg=",
       "requires": {
-        "chalk": "1.1.3",
-        "log-symbols": "1.0.2",
-        "plur": "2.1.2",
-        "repeat-string": "1.6.1",
-        "string-width": "1.0.2",
-        "text-table": "0.2.0",
-        "vfile-sort": "1.0.0"
+        "chalk": "^1.1.0",
+        "log-symbols": "^1.0.2",
+        "plur": "^2.0.0",
+        "repeat-string": "^1.5.0",
+        "string-width": "^1.0.0",
+        "text-table": "^0.2.0",
+        "vfile-sort": "^1.0.0"
       }
     },
     "vfile-sort": {
@@ -9067,15 +8191,15 @@
       "resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
       "integrity": "sha1-0bFPOdLiy0q4xAmPdW/ksWTkc9Q=",
       "requires": {
-        "wrap-fn": "0.1.5"
+        "wrap-fn": "^0.1.0"
       }
     },
     "which": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-pm-runs": {
@@ -9084,11 +8208,11 @@
       "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
     },
     "wide-align": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.2 || 2"
       }
     },
     "word-wrap": {
@@ -9120,7 +8244,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
     },
     "ws": {
@@ -9128,8 +8252,8 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
       "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
       "requires": {
-        "options": "0.0.6",
-        "ultron": "1.0.2"
+        "options": ">=0.0.5",
+        "ultron": "1.0.x"
       }
     },
     "xtend": {
@@ -9148,7 +8272,7 @@
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
       "dev": true,
       "requires": {
-        "fd-slicer": "1.0.1"
+        "fd-slicer": "~1.0.1"
       }
     },
     "zerr": {

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
   },
   "devDependencies": {
     "electro": "^2.1.1",
-    "electron": "^2.0.5",
+    "electron": "^2.0.6",
     "standard": "^8.6.0"
   }
 }


### PR DESCRIPTION
I'm having an issue with an old version of `sodium-native` which:

1. Doesn't recognize that I already have libsodium.
2. Is missing a critical file because of a [silly error](https://github.com/sodium-friends/sodium-native/issues/43#issuecomment-345478719).

This PR is the result of running [`npm update`](https://docs.npmjs.com/cli/update). Once this is merged I'll be able to get [`patchbay-git`](https://aur.archlinux.org/packages/patchbay-git/) working with native crypto. :business_suit_levitating: 