### PR TITLE
Circumvent "not a valid hash:undefined"

### DIFF
--- a/blob/sync/url.js
+++ b/blob/sync/url.js
@@ -4,8 +4,11 @@ exports.gives = nest('blob.sync.url')
 
 exports.create = function (api) {
   return nest('blob.sync.url', function (id) {
-    // return id
-
-    return 'http://localhost:8989/blobs/get/' + id
+    if (id === undefined)  {
+      console.warn('value of "undefined" was passed as a blob ID')
+      return '#'
+    } else {
+      return 'http://localhost:8989/blobs/get/' + id
+    }
   })
 }


### PR DESCRIPTION
Resolves #231, although I've added a warning as a reminder that something *is* wrong, and that we should probably refactor `about.js` so that we aren't asking for junk identifiers like `undefined`.