### PR TITLE
Make quote work again

### DIFF
--- a/app/html/app.js
+++ b/app/html/app.js
@@ -29,7 +29,8 @@ exports.create = function (api) {
     // runs all the functions in app/sync/initialise
 
     api.history.obs.location()(loc => {
-      api.app.sync.goTo(loc || {})
+      if (!api.app.html.tabs().currentPage()) // close
+        api.app.sync.goTo(loc || {})
     })
 
     return App

--- a/app/html/tabs.js
+++ b/app/html/tabs.js
@@ -59,7 +59,7 @@ exports.create = function (api) {
     }
     _tabs.nextTab = () => _tabs.currentPage() && _tabs.selectRelative(1)
     _tabs.previousTab = () => _tabs.currentPage() && _tabs.selectRelative(-1)
-    _tabs.closeCurrentTab = () => { _tabs.currentPage() && _tabs.remove(_tabs.selected[0]) }
+    _tabs.closeCurrentTab = () => _tabs.currentPage() && _tabs.remove(_tabs.selected[0])
 
     // # TODO: review - this works but is strange
     initialTabs.forEach(p => api.app.sync.goTo(p))


### PR DESCRIPTION
This should fix so we don't get double quote and also make keyboard shortcuts behave the same way as clicking close. Depends on https://github.com/hyperhype/hypertabs/pull/14