### PR TITLE
Remove when() on non-observables

### DIFF
--- a/contact/html/relationships.js
+++ b/contact/html/relationships.js
@@ -62,7 +62,7 @@ exports.create = function (api) {
 
     return h('Relationships', [
       h('header', 'Relationships'),
-      when(id !== myId,
+      id !== myId ?
         h('div.your-status', [
           h('header', 'Your status'),
           h('section -friendship', [
@@ -90,7 +90,7 @@ exports.create = function (api) {
             ])
           ])
         ])
-      ),
+      : undefined,
       computed(blockers, blockers => {
         if (blockers.length === 0) return ''
 

--- a/message/html/compose.js
+++ b/message/html/compose.js
@@ -62,8 +62,8 @@ exports.create = function (api) {
       'ev-focus': send(channelInputFocused.set, true),
       placeholder: '#channel (optional)',
       value: computed(meta.channel, ch => ch ? '#' + ch : null),
-      disabled: when(meta.channel, true),
-      title: when(meta.channel, 'Reply is in same channel as original message')
+      disabled: meta.channel ?  true : undefined,
+      title: meta.channel ? 'Reply is in same channel as original message' : undefined
     })
 
     var draftPerstTimeout = null

--- a/message/html/render/about.js
+++ b/message/html/render/about.js
@@ -43,9 +43,9 @@ exports.create = function (api) {
     about = about || link
 
     const metaData = [
-      when(name, h('div', [ h('strong', 'Name: '), name ])),
-      when(description, h('div', [ h('strong', 'Description: '), description ])),
-      when(image, h('img', { src: api.blob.sync.url(image), style: { 'margin-top': '.5rem' } }))
+      name ? h('div', [ h('strong', 'Name: '), name ]) : undefined,
+      description ? h('div', [ h('strong', 'Description: '), description ]) : undefined,
+      image ? h('img', { src: api.blob.sync.url(image), style: { 'margin-top': '.5rem' } }): undefined
     ]
 
     if (!ref.isFeed(about)) {


### PR DESCRIPTION
This removes `when()` from being used on values that are non-observable, replacing them with a ternary function that does the same thing **except that it doesn't execute both branches**. This means that it resolves #231 without treating just the symptoms (like #232). We *may* be able to replace `undefined` with `null`, but in an effort to keep things from breaking I've matched `when()`'s behavior exactly.