### PR TITLE
Add `npm run rebuild` as postinstall script

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ This runs an embedded sbot with all the right plugins already installed.
 git clone https://github.com/ssbc/patchbay.git
 cd patchbay
 npm install
-npm run rebuild
 ```
 
 Patchbay doesn't give you a way to join pubs yet, so this is good if you've already done that with another client (like Patchwork).
@@ -114,7 +113,6 @@ Install Patchbay
 git clone https://github.com/ssbc/patchbay.git
 cd patchbay
 npm install
-npm run rebuild
 ```
 
 ## Running the desktop app

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "rebuild": "cross-script npm rebuild --runtime=electron \"--target=$(electron -v)\" \"--abi=$(electron --abi)\" --disturl=https://atom.io/download/atom-shell",
     "start": "electron index.js -- --title patchbay",
     "start-frameless": "FRAME=false npm start",
-    "dev": "echo 'run your own sbot!' && electro main.js -- --title patchbay --icon ./assets/icon.png"
+    "dev": "echo 'run your own sbot!' && electro main.js -- --title patchbay --icon ./assets/icon.png",
+    "postinstall": "npm run rebuild"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
This should simplify installation and maintenance, especially for new users. Instead of having to run two commands, this branch now runs `npm run rebuild` directly after `npm install` or `npm ci`.