### PR TITLE
Add icon to indicate private message

### DIFF
--- a/message/html/meta/private.js
+++ b/message/html/meta/private.js
@@ -1,0 +1,23 @@
+const nest = require('depnest')
+const { h } = require('mutant')
+
+exports.gives = nest('message.html.meta')
+
+exports.needs = nest({
+  'about.obs.name': 'first',
+  'message.obs.likes': 'first'
+})
+
+exports.create = (api) => {
+  return nest('message.html.meta', private)
+
+  function private (msg) {
+    if (msg.value.private) {
+      return h('i.fa.fa-lock', {
+        title: 'Private'
+      })
+    } else {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
I've seen some confusion about private messages showing up in profile feeds and such, which can be confusing (and scary!) when private messages *look* public. I'm not sure what the best solution would be, but personally I'd love even just a small icon to indicate that this is private. I've written the minimum viable code to prototype this, and I'd love input on what can be improved.

![screenshot from 2018-08-22 07-03-47](https://user-images.githubusercontent.com/537700/44468689-a6852f80-a5da-11e8-93cb-4576ab8378ea.png)

Here are some things that I think might be worth thinking about:

- **Color:** Should it match the #bbb plus icon? Or maybe a green to indicate security?
- **Decryptability:** Currently *all* private messages are indicated, regardless of whether *you* can see their contents. I was thinking that readable private messages should have an unlocked icon, but I'm concerned that might be misunderstood as "insecure". We could also use color, maybe #bbb by default but green if you can read it?
- **Text:** Hovering over the lock icon just says "Private", but it might be more helpful to display more text -- maybe different text depending on whether it's encrypted for you?