### PR TITLE
Don't init suggestion cache for abouts during startup

### DIFF
--- a/app/sync/initialise/suggestionCaches.js
+++ b/app/sync/initialise/suggestionCaches.js
@@ -11,7 +11,8 @@ exports.create = function (api) {
   return nest('app.sync.initialise', init)
 
   function init () {
-    api.about.async.suggest()
+    // lazy load abouts on first use, can be quite heavy during startup
+    //api.about.async.suggest()
     api.channel.async.suggest()
   }
 }


### PR DESCRIPTION
This decreases the startup time for me from 18 sec to 12 sec. The suggestions will just be loading when we need then instead so we shouldn't loose any functionality (I think?). 

The test was conducted this: https://github.com/ssbc/patchcore/pull/69