### PR TITLE
Replace /public with /posts in default tabs

### DIFF
--- a/app/sync/initialise/settings.js
+++ b/app/sync/initialise/settings.js
@@ -12,7 +12,7 @@ exports.needs = nest({
 
 const defaults = {
   patchbay: {
-    defaultTabs: ['/public', '/inbox', '/notifications'],
+    defaultTabs: ['/posts', '/inbox', '/notifications'],
     accessibility: {
       invert: false,
       saturation: 100,


### PR DESCRIPTION
This PR means that future versions will default to opening `/posts` rather than `/public` when the application is opened with no "default tabs" customization. This will not effect users who have customized this to their liking.

It's worth mentioning that this is likely a personal preference, so if it's not a good candidate for `master` then I don't mind closing this at all. Also, if there are any unresolved bugs in `/posts` I'd be happy to take a look at them before merging is considered.