### PR TITLE
Fix `Markdown > h2` font-size

### DIFF
--- a/app/styles/mcss/markdown.mcss
+++ b/app/styles/mcss/markdown.mcss
@@ -86,7 +86,7 @@ Markdown {
     margin-bottom: .5em
   }
   h1 { font-size: 1.4rem }
-  h2 { font-size: 1.2em }
+  h2 { font-size: 1.2rem }
   h3 { font-size: 1.15rem }
   h4 { font-size: 1.12rem }
   h5 { font-size: 1.1rem }


### PR DESCRIPTION
I noticed that h3 elements are bigger than h2 elements, which is caused by a typo regarding `em` sizing versus `rem` sizing. Infinitely trivial.