### PR TITLE
Allow future ssb-chess-mithril updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "ssb-blob-files": "^1.1.1",
     "ssb-blobs": "^1.1.5",
     "ssb-chess-db": "^1.0.4",
-    "ssb-chess-mithril": "1.0.6",
+    "ssb-chess-mithril": "^1.0.6",
     "ssb-config": "^2.3.0",
     "ssb-ebt": "^5.2.3",
     "ssb-friends": "^3.1.3",


### PR DESCRIPTION
Hey @Happy0! I've noticed you've been bumping this manually, so I figured I might just add a `^` to match `1.x.x`.