### PR TITLE
Send logs to stdout with console require

### DIFF
--- a/assets/base.html
+++ b/assets/base.html
@@ -4,23 +4,19 @@
   <body>
     <script>
       // redirect console to main process
-      var electron = require('electron')
-      var localLog = console.log
-      var localError = console.error
-      var remoteLog = electron.remote.getGlobal('console').log
-      var remoteError = electron.remote.getGlobal('console').error
+      const { log: remoteLog, error: remoteErr } = require('console')
+      const { log: localLog, error: localErr } = console
 
       console.log = function (...args) {
-        localLog.apply(console, args)
+        localLog(...args)
         remoteLog(...args)
       }
 
       console.error = function (...args) {
-        localError.apply(console, args)
-        remoteError(...args)
+        localErr(...args)
+        remoteErr(...args)
       }
 
-      process.exit = electron.remote.app.quit
       // redirect errors to stderr
       window.addEventListener('error', function (e) {
         e.preventDefault()


### PR DESCRIPTION
cc: @mixmix @cryptix I figured it out!

Resolves #252 

## Before

Prepended "Error " in each nested object, for unknown reasons.

```
Error {
  key: '%WAqQoKWBkL20Hd2wUUTh6u8E9CcrW7E+OJTUEo7LYWQ=.sha256',
  value:
   Error {
     previous: '%dwAq7w5F9iAMCKVz9X0kOMxGkjlENOO6vJLcdcJFohc=.sha256',
     author: '@+oaWWDs8g73EZFUMfW37R/ULtFEjwKN/DczvdYihjbU=.ed25519',
     sequence: 6654,
     timestamp: 1540829857167,
     hash: 'sha256',
     content: Error { type: 'vote', channel: 'ssb-dev', vote: [Error] },
     signature:
      '4552sjoQfjE7HKS0mmxVrmvzKPh+BwN1qNS5VeAlz7sZYslGjH+wC9kj6/0y4h/DlpJSpLF98sTEjH4mDh9DDw==.sig.ed25519' },
  timestamp: 1540829857186 }
```

## After

Normal JS output with pretty-print (and coloring in Electron 3).

```js
{ key: '%V7gfMPLT3dpPBB5ToNJiZA3lCW849Cew9XvXboZUJPM=.sha256',
  value:
   { previous: '%WnRG7Hu9sVCs5BAzP5tg6tAefcdXMG49PWKNb4E3fiU=.sha256',
     author: '@+oaWWDs8g73EZFUMfW37R/ULtFEjwKN/DczvdYihjbU=.ed25519',
     sequence: 6678,
     timestamp: 1540841642867,
     hash: 'sha256',
     content: { type: 'vote', channel: 'ssb-dev', vote: [Object] },
     signature:
      'PUrwPci+WeG7pQY4vo45Kl3xtO5BnZUtc8gpnuGWMAO0ZMU+3jxoQvQ6CYwXkyfBagof/EhdUCCCyiiQ/20BDg==.sig.ed25519' },
  timestamp: 1540841642891.001 }
```

## Considerations

I'm not really sure why this resolves the issue, but based on Electron's magical modifications to `console.log` I didn't even want to dive into why it was so broken. I've also removed the `process.exit` expression since it didn't seem to do anything in my testing.