### PR TITLE
fix reopening main window on macOS

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,13 @@ electron.app.on('ready', () => {
     quitting = true
   })
 
+  electron.app.on('activate', function (e) {
+    // reopen the app when dock icon clicked on macOS
+    if (windows.main) {
+      windows.main.show()
+    }
+  })
+
   // allow inspecting of background process
   electron.ipcMain.on('open-background-devtools', function (ev, config) {
     if (windows.background) {


### PR DESCRIPTION
In the current master of patchbay, you can close the main window on macOS and Patchbay continues to run in the background. However, when you click on the dock icon, nothing happens. The only way to show the main window again is to right click, quit, and then relaunch.

**This PR adds an `on('activate')` handler that shows the window again.**

This is safe to merge as it mostly just brings the patchbay `index.js` inline with the patchwork one.
