### PR TITLE
Use `require()` instead of invisible Electron window

### DIFF
--- a/assets/base.html
+++ b/assets/base.html
@@ -2,27 +2,13 @@
 <html>
   <head></head>
   <body>
-    <script>
-      // redirect console to main process
-      const { log: remoteLog, error: remoteErr } = require('console')
-      const { log: localLog, error: localErr } = console
-
-      console.log = function (...args) {
-        localLog(...args)
-        remoteLog(...args)
-      }
-
-      console.error = function (...args) {
-        localErr(...args)
-        remoteErr(...args)
-      }
-
-      // redirect errors to stderr
-      window.addEventListener('error', function (e) {
-        e.preventDefault()
-        console.error(e.error.stack || 'Uncaught ' + e.error)
-      })
-    </script>
   </body>
+  <script>
+    // redirect errors to stderr
+    window.addEventListener('error', function (e) {
+      e.preventDefault()
+      require('console').error(e.error.stack || 'Uncaught ' + e.error)
+    })
+  </script>
 </html>
 

--- a/assets/base.html
+++ b/assets/base.html
@@ -4,10 +4,12 @@
   <body>
   </body>
   <script>
+    const serverConsole = require('console')
+
     // redirect errors to stderr
     window.addEventListener('error', function (e) {
       e.preventDefault()
-      require('console').error(e.error.stack || 'Uncaught ' + e.error)
+      serverConsole.error(e.error.stack || 'Uncaught ' + e.error)
     })
   </script>
 </html>

--- a/index.js
+++ b/index.js
@@ -7,6 +7,10 @@ var Path = require('path')
 var windows = {}
 var quitting = false
 
+process.on('uncaughtException', function (error) {
+    console.error(error)
+});
+
 console.log('STARTING electron')
 electron.app.on('ready', () => {
   startMenus()

--- a/index.js
+++ b/index.js
@@ -11,11 +11,7 @@ console.log('STARTING electron')
 electron.app.on('ready', () => {
   startMenus()
 
-  startBackgroundProcess()
-  // wait until server has started before opening main window
-  electron.ipcMain.once('server-started', function (ev, config) {
-    openMainWindow()
-  })
+  startBackgroundProcess(openMainWindow)
 
   electron.app.on('before-quit', function () {
     quitting = true
@@ -36,24 +32,10 @@ electron.app.on('ready', () => {
   })
 })
 
-function startBackgroundProcess () {
+function startBackgroundProcess (cb) {
   if (windows.background) return
 
-  windows.background = openWindow(Path.join(__dirname, 'server.js'), {
-    title: 'patchbay-server',
-    show: false,
-    connect: false,
-    width: 150,
-    height: 150,
-    center: true,
-    fullscreen: false,
-    fullscreenable: false,
-    maximizable: false,
-    minimizable: false,
-    resizable: false,
-    skipTaskbar: true,
-    useContentSize: true
-  })
+  require('./server')(cb)
 }
 
 function openMainWindow () {

--- a/server.js
+++ b/server.js
@@ -1,7 +1,6 @@
 // formerly background-process.js
 var fs = require('fs')
 var Path = require('path')
-var electron = require('electron')
 
 console.log('STARTING SBOT')
 
@@ -34,4 +33,5 @@ var config = require('./config').create().config.sync.load()
 var sbot = createSbot(config)
 var manifest = sbot.getManifest()
 fs.writeFileSync(Path.join(config.path, 'manifest.json'), JSON.stringify(manifest))
-electron.ipcRenderer.send('server-started')
+
+module.exports = (cb) => cb()


### PR DESCRIPTION
I think this is an improvement? It's less code and *feels* cleaner, but I don't know if it's actually a very big performance improvement.

- `server.js` runs in the main process rather than opening an invisible Electron window
- the "server-started" event is replaced with a simple callback
- errors from the renderer are still passed to the terminal
- `console.log`s from the renderer only show up in the dev tools, not the terminal
- errors in the main process will be output as text (no more "A JavaScript error occurred in the main process" windows)
