### PR TITLE
Use the known 'light purple' color for links on main posts.

### DIFF
--- a/app/page/posts.mcss
+++ b/app/page/posts.mcss
@@ -122,6 +122,7 @@ ThreadCard {
           :first-of-type { margin-top: 0 }
         }
         (img) { max-width: 100% }
+        (a) { color: #db67ed }
       }
     }
 


### PR DESCRIPTION
Following on from the discussion in #300, this lightens up the link colors for the black background posts.

I'm unclear if this color is desirable when the 'invert colors' thing is toggled. I've included screenshots to show each option.


### Before
![screenshot from 2019-01-15 08-20-50](https://user-images.githubusercontent.com/3853/51194043-1c967580-189f-11e9-9b82-eeb78adf3da2.png)


### After
![screenshot from 2019-01-15 08-20-27](https://user-images.githubusercontent.com/3853/51194007-0983a580-189f-11e9-8488-6b899d4090e1.png)

### After (invert)
![screenshot from 2019-01-15 08-22-30](https://user-images.githubusercontent.com/3853/51194021-0d172c80-189f-11e9-93d3-7c1501198cdb.png)


Fixes #293 