### PR TITLE
Fix preformatted code blocks so they have the same look on posts view.

### DIFF
--- a/app/page/posts.mcss
+++ b/app/page/posts.mcss
@@ -122,6 +122,9 @@ ThreadCard {
           :first-of-type { margin-top: 0 }
         }
         (img) { max-width: 100% }
+        (pre) { background-color: #000; }
+        (code) { background-color: #000; }
+
       }
     }
 


### PR DESCRIPTION
Fixes #304 

### Before
![screenshot from 2019-01-16 19-46-10](https://user-images.githubusercontent.com/3853/51294586-734b9e80-19c8-11e9-9053-7a85a8590972.png)

### After
![screenshot from 2019-01-16 19-45-52](https://user-images.githubusercontent.com/3853/51294589-76468f00-19c8-11e9-9387-d736032fda68.png)

### After w/ highlight
![screenshot from 2019-01-16 19-54-10](https://user-images.githubusercontent.com/3853/51294602-82cae780-19c8-11e9-8826-d81d247e340a.png)
