### PR TITLE
fix device scope

### DIFF
--- a/config.js
+++ b/config.js
@@ -33,7 +33,7 @@ function addSockets (config) {
     config,
     {
       connections: {
-        incoming: { unix: [{ scope: 'local', transform: 'noauth', server: true }] }
+        incoming: { unix: [{ scope: 'device', transform: 'noauth', server: true }] }
       },
       remote: `unix:${Path.join(config.path, 'socket')}:~noauth:${pubkey}` // overwrites
     }


### PR DESCRIPTION
`local/private` scope is the local network, i.e. wifi. _not_ localhost. that is the `device` scope.

A unix socket can only be connected to within the device.

This will fix https://github.com/ssbc/ssb-server/issues/640

I'm not really happy with the scope names. It seems like a confusion as to meaning of the names lead to this bug..

I'd kinda lead towards "device" "nearby" "global" or something. get away from networking terms?