### PR TITLE
WIP: use `compatibility` for testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start-frameless": "FRAME=false npm start",
     "lite": "echo 'run your own sbot!' && electro lite.js -- --title patchbay --icon ./node_module/ssb-ahoy/electron/assets/icon.png",
     "dist": "electron-builder",
-    "test": "standard",
+    "test": "standard && compatibility",
     "lint": "standard --fix"
   },
   "browserify": {
@@ -26,6 +26,21 @@
       "IntersectionObserver"
     ]
   },
+  "compatibility": [
+    "ssb-master",
+    "ssb-friends",
+    "ssb-replicate",
+    "ssb-invite",
+    "ssb-ebt"
+  ],
+  "_compatibility": [
+    "ssb-ws",
+    "ssb-legacy-conn",
+    "ssb-friends",
+    "ssb-blobs",
+    "ssb-chess-db",
+    "ssb-friend-pub"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ssbc/patchbay.git"
@@ -91,6 +106,7 @@
     "scuttle-blog": "^1.0.1",
     "scuttle-book": "^2.0.6",
     "scuttle-thread": "^1.0.2",
+    "secret-stack": "^6.1.2",
     "setimmediate": "^1.0.5",
     "ssb-about": "^2.0.1",
     "ssb-ahoy": "^1.0.0",
@@ -100,24 +116,30 @@
     "ssb-chess-db": "^1.0.6",
     "ssb-chess-mithril": "1.0.10",
     "ssb-config": "^3.3.0",
+    "ssb-db": "^19.2.0",
     "ssb-ebt": "^5.6.4",
     "ssb-friend-pub": "^1.0.7",
-    "ssb-friends": "^4.1.0",
+    "ssb-friends": "^4.1.2",
     "ssb-invite": "~2.0.4",
     "ssb-legacy-conn": "^1.0.25",
+    "ssb-local": "^1.0.0",
+    "ssb-logging": "^1.0.0",
+    "ssb-master": "^1.0.2",
     "ssb-meme": "^1.0.4",
     "ssb-mentions": "^0.5.0",
     "ssb-mutual": "^0.1.0",
+    "ssb-no-auth": "^1.0.0",
+    "ssb-onion": "^1.0.0",
     "ssb-ooo": "^1.1.1",
     "ssb-private": "^0.2.3",
     "ssb-query": "^2.1.0",
     "ssb-ref": "^2.13.6",
     "ssb-replicate": "^1.3.0",
     "ssb-search": "^1.1.2",
-    "ssb-server": "^14.1.12",
     "ssb-sort": "^1.1.0",
     "ssb-suggest": "^1.0.4",
     "ssb-tangle": "^1.0.1",
+    "ssb-unix-socket": "^1.0.0",
     "ssb-unread": "^1.0.5",
     "ssb-uri": "^1.0.1",
     "ssb-ws": "~6.0.0",
@@ -126,11 +148,23 @@
     "xtend": "^4.0.1"
   },
   "devDependencies": {
+    "@types/node": "^11.13.11",
+    "cat-names": "^2.0.0",
+    "compatibility": "^1.0.0",
+    "cont": "^1.0.3",
+    "dog-names": "^1.0.2",
     "electro": "^2.1.1",
     "electron": "^4.2.0",
     "electron-builder": "^20.41.0",
     "eslint-config-standard": "^12.0.0",
-    "standard": "^12.0.1"
+    "run-series": "^1.1.8",
+    "ssb-client": "^4.7.5",
+    "ssb-generate": "^1.0.1",
+    "ssb-gossip": "^1.0.10",
+    "ssb-keys": "^7.1.6",
+    "standard": "^12.0.1",
+    "tape": "^4.10.2",
+    "typescript": "^3.3.4000"
   },
   "build": {
     "appId": "org.ssbc.patchbay",
@@ -154,3 +188,13 @@
     }
   }
 }
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
patchbay includes a _distribution_ of ssb-server. It uses a custom selection of modules and versions.
theirfore, it should run those modules tests, so that it's can detect when something breaks.

this uses a tool recently refactored out of ssb-server. I present this as a Work in Progress, because there where a few small problems
* patchbay runs inside electron, so native modules are built for the electron version which means that they don't run in node... currently i do `npm rebuild` before running the tests. that's not ideal.
* also, lots of things depend on ssb-server, which the script that resolved versions originally special-cased for ssb-server... am wondering if the dependency checking script is a little bit pedantic

what are your thoughts @christianbundy ?