### PR TITLE
Use ssb-lan instead of ssb-local for better privacy

### DIFF
--- a/app/sync/initialise/lan-discovery.js
+++ b/app/sync/initialise/lan-discovery.js
@@ -1,0 +1,32 @@
+const { onceTrue } = require('mutant')
+const nest = require('depnest')
+const pull = require('pull-stream')
+
+exports.needs = nest({
+  'sbot.obs.connection': 'first',
+  'config.sync.get': 'first'
+})
+
+exports.gives = nest('app.sync.initialise')
+
+exports.create = function (api) {
+  return nest('app.sync.initialise', lanDiscovery)
+
+  function lanDiscovery () {
+    onceTrue(api.sbot.obs.connection, server => {
+      const config = api.config.sync.get()
+      console.log(config)
+      if(config.gossip && config.gossip.local === false)
+        return
+
+      server.lan.start()
+
+      pull(
+        server.lan.discoveredPeers(),
+        pull.drain((discovery) => {
+          server.gossip.add(discovery.address, 'local')
+        })
+      )
+    })
+  }
+}

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const plugins = [
   'ssb-unix-socket',
   'ssb-no-auth',
   'ssb-onion',
-  'ssb-local',
+  'ssb-lan',
   'ssb-logging',
 
   'ssb-legacy-conn',

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,14 @@
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.2"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+          "dev": true
+        }
       }
     },
     "@f/zip-obj": {
@@ -400,15 +408,15 @@
       }
     },
     "@types/debug": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.4.tgz",
-      "integrity": "sha512-D9MyoQFI7iP5VdpEyPZyjjqIJ8Y8EDNQFIFVLOmeg1rI1xiHOChyUPMPRUVfqFCerxfE+yS3vMyj37F6IdtOoQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
+      "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==",
       "dev": true
     },
     "@types/node": {
-      "version": "10.14.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.12.tgz",
-      "integrity": "sha512-QcAKpaO6nhHLlxWBvpc4WeLrTvPqlHOvaj0s5GriKkA1zq+bsFBPpfYCvQhLqLgYlIko8A9YrPdaMHCo5mBcpg=="
+      "version": "10.14.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.15.tgz",
+      "integrity": "sha512-CBR5avlLcu0YCILJiDIXeU2pTw7UK/NIxfC63m7d7CVamho1qDEzXKkOtEauQRPMy6MI8mLozth+JJkas7HY6g=="
     },
     "abstract-leveldown": {
       "version": "6.0.3",
@@ -428,9 +436,9 @@
       }
     },
     "acorn": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.0.tgz",
-      "integrity": "sha512-8oe72N3WPMjA+2zVG71Ia0nXZ8DpQH+QyyHO+p06jT8eg8FGG3FbcUIi8KziHlAfheJQZeoqbvq1mQSQHXKYLw=="
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
+      "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q=="
     },
     "acorn-dynamic-import": {
       "version": "4.0.0",
@@ -612,9 +620,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
-          "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==",
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
       }
@@ -1054,13 +1062,6 @@
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
-        }
       }
     },
     "babel-template": {
@@ -1178,15 +1179,15 @@
       }
     },
     "base64-js": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
       "dev": true
     },
     "base64-url": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-2.2.2.tgz",
-      "integrity": "sha512-JMAkNo3MJ7GG2CHPVMiGPrzGQizUcVE9qvCU6pxQln4aYZZgYM6BJHXbawDegSoryvsKGrK3FuBO9IuGWErRLQ=="
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-2.3.2.tgz",
+      "integrity": "sha512-2QpXjtjndKqPn9JKBpMTCbDGpgicfLUu+N5Y1vEfbuyqb1MN1D68C9YKCth4SjTHRvJleF3tPuxhLbH79MM0iQ=="
     },
     "bash-color": {
       "version": "0.0.4",
@@ -1231,9 +1232,9 @@
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
     },
     "binary-search": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.5.tgz",
-      "integrity": "sha512-RHFP0AdU6KAB0CCZsRMU2CJTk2EpL8GLURT+4gilpjr1f/7M91FgUMnXuQLmf3OKLet34gjuNFwO7e4agdX5pw=="
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.6.tgz",
+      "integrity": "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA=="
     },
     "bindings": {
       "version": "1.3.1",
@@ -1594,9 +1595,9 @@
           "dev": true
         },
         "source-map-support": {
-          "version": "0.5.12",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
-          "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+          "version": "0.5.13",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+          "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
           "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",
@@ -2001,9 +2002,9 @@
       "integrity": "sha512-RcdumNsM6fJZ5HHbYunqj2bpurVRGsXour3OR+SlLEHFhG6ALm54i6Osnh+OvO7kEoSBzwExpblYFH8zKQiEPw=="
     },
     "chessground": {
-      "version": "7.6.9",
-      "resolved": "https://registry.npmjs.org/chessground/-/chessground-7.6.9.tgz",
-      "integrity": "sha512-x+XFjbZ8STPL4gQch8o2MN+QOPX3bwGmcXjSXpiho1p+qTQZxeEtREkXkToxGTXwcNbumRRlFjcdPpbCSah0EA=="
+      "version": "7.6.10",
+      "resolved": "https://registry.npmjs.org/chessground/-/chessground-7.6.10.tgz",
+      "integrity": "sha512-kAnS6hy7NNdGLu6H1b2IOodwEHu9cDfaG/GVhh96KuBm2D9llZ2Ccf/j0sLwmMQctn3cIxOXV4yeRsT4/8szzg=="
     },
     "chloride": {
       "version": "2.2.14",
@@ -2123,6 +2124,31 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
       "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A=="
+    },
+    "chrome-dgram": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/chrome-dgram/-/chrome-dgram-3.0.2.tgz",
+      "integrity": "sha512-Ay741EHF/Ib18un+LUtBNK43NrabD6GOuwVaka7uUbV0gFRLEPULm2Q05YSzRNBtSrbaO4eErmDdniiy/u8Lig==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "run-series": "^1.1.2"
+      }
+    },
+    "chrome-dns": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/chrome-dns/-/chrome-dns-1.0.1.tgz",
+      "integrity": "sha512-HqsYJgIc8ljJJOqOzLphjAs79EUuWSX3nzZi2LNkzlw3GIzAeZbaSektC8iT/tKvLqZq8yl1GJu5o6doA4TRbg==",
+      "requires": {
+        "chrome-net": "^3.3.2"
+      }
+    },
+    "chrome-net": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/chrome-net/-/chrome-net-3.3.2.tgz",
+      "integrity": "sha512-BHxWfA9MDnh0C1By5q1DnF1vRS7vfBi2PrqTHIIt1HA4hM6l2xkHzoazbDlZcrDrMfjNs6fojKG+ZD0JmlnNWg==",
+      "requires": {
+        "inherits": "^2.0.1"
+      }
     },
     "chromium-pickle-js": {
       "version": "0.2.0",
@@ -3140,9 +3166,9 @@
       }
     },
     "electron": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-4.2.6.tgz",
-      "integrity": "sha512-qnaQXQcRKugXoQ7/4J4lYKzyU/RJMK/qrIGyC8KsgGG/IVVagolNPYy7QrsGpJ7YwpQHzNjwtDNaJ/UI7VTCyA==",
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-4.2.9.tgz",
+      "integrity": "sha512-zC7K3GOiZKmxqllVG/qq/Gx+qQvyolKj5xKKwXMqIGekfokEW2hvoIO5Yh7KCoAh5dqBtpzOJjS4fj1se+YBcg==",
       "requires": {
         "@types/node": "^10.12.18",
         "electron-download": "^4.1.0",
@@ -3441,12 +3467,6 @@
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
           "dev": true
         },
-        "mime": {
-          "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
-          "dev": true
-        },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -3594,13 +3614,6 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "requires": {
         "is-arrayish": "^0.2.1"
-      },
-      "dependencies": {
-        "is-arrayish": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
-        }
       }
     },
     "es-abstract": {
@@ -3901,9 +3914,9 @@
       }
     },
     "eslint-module-utils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.0.tgz",
-      "integrity": "sha512-14tltLm38Eu3zS+mt0KvILC3q8jyIAH518MlG+HO0p+yK885Lb1UHTY/UgR91eOyGdmxAPb+OLoW4znqIT6Ndw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.1.tgz",
+      "integrity": "sha512-H6DOj+ejw7Tesdgbfs4jeS4YMFrT8uI8xwd1gtQqXssaR0EQ26L+2O/w6wkYFy2MymON0fTwHmXBvvfLNZVZEw==",
       "dev": true,
       "requires": {
         "debug": "^2.6.8",
@@ -4170,9 +4183,9 @@
       "integrity": "sha512-nSCWn1jkSq2QAtkaVLJZY2ezwcFO161HVc174zL1KPW3RJ+O6C3eJb8Nx7OXzvhoEv+nLgSR1g71oWUHUDTrJA=="
     },
     "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "event-emitter": {
       "version": "0.3.5",
@@ -4664,9 +4677,9 @@
       }
     },
     "flumelog-offset": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/flumelog-offset/-/flumelog-offset-3.4.2.tgz",
-      "integrity": "sha512-pj8gc3idzbpWjGQPXvRwNdkqtHPx/0olLsyip3u1lULP+LVvcYGYvTt8AU0frKWSFsGST0B8WVh9DrZ5rsEzbg==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/flumelog-offset/-/flumelog-offset-3.4.3.tgz",
+      "integrity": "sha512-XG2uVxoMjwcWKHniKSp1Iyo4XSZqvpK/KcQNDfTUM+ajpehLveMTd5H0cXWzaVlNjkHE0oGDGL7CgHrDyixiIg==",
       "requires": {
         "aligned-block-file": "^1.2.0",
         "append-batch": "0.0.2",
@@ -4676,6 +4689,7 @@
         "obv": "0.0.1",
         "pull-cursor": "^3.0.0",
         "pull-looper": "^1.0.0",
+        "pull-stream": "^3.6.13",
         "uint48be": "^2.0.1"
       },
       "dependencies": {
@@ -5563,9 +5577,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
-      "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg=="
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz",
+      "integrity": "sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw=="
     },
     "graphreduce": {
       "version": "3.0.4",
@@ -5682,9 +5696,9 @@
       "integrity": "sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw="
     },
     "highlight.js": {
-      "version": "9.15.8",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.8.tgz",
-      "integrity": "sha512-RrapkKQWwE+wKdF73VsOa2RQdIoO3mxwJ4P8mhbI6KYJUraUHRKM5w5zQQKXNk0xNL4UVRdulV9SBJcmzJNzVA=="
+      "version": "9.15.9",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.9.tgz",
+      "integrity": "sha512-M0zZvfLr5p0keDMCAhNBp03XJbKBxUx5AfyfufMdFMEP4N/Xj6dh0IqC75ys7BAzceR34NgcvXjupRVaHBPPVQ=="
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -5696,9 +5710,27 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.2.tgz",
+      "integrity": "sha512-CyjlXII6LMsPMyUzxpTt8fzh5QwzGqPmQXgY/Jyf4Zfp27t/FvfhwoE/8laaMUcMy816CkWF20I7NeQhwwY88w==",
+      "requires": {
+        "lru-cache": "^5.1.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+        }
+      }
     },
     "howler": {
       "version": "2.1.2",
@@ -5754,9 +5786,9 @@
       "integrity": "sha1-KA0DNjeRmTBrLhUY49X2OBy4UH0="
     },
     "hypercore": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-7.5.0.tgz",
-      "integrity": "sha512-Uuk0xmc73YzkqRCcLtAUTm5dmtdvg6yG3sMytIJuf/bu+9SB5pej0tILEBgnI+TmWRdJrxd242j1C4ND96V0xg==",
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-7.6.1.tgz",
+      "integrity": "sha512-ZQ1HdFXa9D5cSwXiu6vldYSE5ro6OBtyWdnFr8L/U3PFDCEpIyhyLvoRTscmP+7U2U9ZYSV3NoNHjWlNPIA8Gw==",
       "requires": {
         "array-lru": "^1.1.0",
         "atomic-batcher": "^1.0.2",
@@ -5768,7 +5800,7 @@
         "flat-tree": "^1.6.0",
         "from2": "^2.3.0",
         "hypercore-crypto": "^1.0.0",
-        "hypercore-protocol": "^6.4.1",
+        "hypercore-protocol": "^6.5.0",
         "inherits": "^2.0.3",
         "inspect-custom-symbol": "^1.1.0",
         "last-one-wins": "^1.0.4",
@@ -5803,9 +5835,9 @@
       }
     },
     "hypercore-protocol": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/hypercore-protocol/-/hypercore-protocol-6.11.0.tgz",
-      "integrity": "sha512-V/0Vru8gavoO++K2QFOAXu7xgBuXcBAjURQ9BQ48DnQ/p4hK4Jy76ulRnppDHpbDthxRziMWLZfmYXncwD63Aw==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/hypercore-protocol/-/hypercore-protocol-6.12.0.tgz",
+      "integrity": "sha512-T3oy9/7QFejqJX2RGcCUU1944e5/eKbLlSz9JPTNN1QbYFJgat/r7eTyOO8SMSLUimUmQx6YBMKhgYbdKzp7Bw==",
       "requires": {
         "buffer-alloc-unsafe": "^1.0.0",
         "buffer-from": "^1.0.0",
@@ -5826,9 +5858,9 @@
       }
     },
     "hyperdrive": {
-      "version": "9.15.0",
-      "resolved": "https://registry.npmjs.org/hyperdrive/-/hyperdrive-9.15.0.tgz",
-      "integrity": "sha512-FXEU/f0B0zIODkllE2eqk6S2Gmd0fcR7vwsbbA+OBRWXARALoCkJedOHBX6ervkkBPi3uQ/wXPTb7wee2j2PiA==",
+      "version": "9.16.0",
+      "resolved": "https://registry.npmjs.org/hyperdrive/-/hyperdrive-9.16.0.tgz",
+      "integrity": "sha512-2iw4baOLmYEs8hWzGUmdgqLHIvjjhiM125kKhQv1aFaiwqDMLtZJ8JsxyeaRZZmMSaC9TuXwjUmU/rrPPgIoVA==",
       "requires": {
         "append-tree": "^2.3.5",
         "duplexify": "^3.5.0",
@@ -5856,13 +5888,6 @@
         "mime": "^2.3.1",
         "pump": "^3.0.0",
         "range-parser": "^1.2.0"
-      },
-      "dependencies": {
-        "mime": {
-          "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
-        }
       }
     },
     "hyperdrive-network-speed": {
@@ -6223,10 +6248,9 @@
       }
     },
     "is-arrayish": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-      "dev": true
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-binary-path": {
       "version": "1.0.1",
@@ -6579,9 +6603,9 @@
       }
     },
     "jpeg-js": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.3.5.tgz",
-      "integrity": "sha512-hvaExqwmQDS8O9qnZAVDXGWU43Tbu1V0wMZmjROjT11jloSgGICZpscG+P6Nyi1BVAvyu2ARRx8qmEW30sxgdQ==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.3.6.tgz",
+      "integrity": "sha512-MUj2XlMB8kpe+8DJUGH/3UJm4XpI8XEgZQ+CiHDeyrGoKPdW/8FJv6ku+3UiYm5Fz3CWaL+iXmD8Q4Ap6aC1Jw==",
       "dev": true
     },
     "js-tokens": {
@@ -6732,13 +6756,14 @@
       }
     },
     "k-rpc-socket": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/k-rpc-socket/-/k-rpc-socket-1.8.0.tgz",
-      "integrity": "sha512-f/9TynsO8YYjZ6JjNNtSSH7CJcIHcio1buy3zqByGxb/GX8AWLdL6FZEWTrN8V3/J7W4/E0ZTQQ+Jt2rVq7ELg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/k-rpc-socket/-/k-rpc-socket-1.11.1.tgz",
+      "integrity": "sha512-8xtA8oqbZ6v1Niryp2/g4GxW16EQh5MvrUylQoOG+zcrDff5CKttON2XUXvMwlIHq4/2zfPVFiinAccJ+WhxoA==",
       "requires": {
         "bencode": "^2.0.0",
-        "buffer-equals": "^1.0.4",
-        "safe-buffer": "^5.1.1"
+        "chrome-dgram": "^3.0.2",
+        "chrome-dns": "^1.0.0",
+        "chrome-net": "^3.3.2"
       },
       "dependencies": {
         "bencode": {
@@ -6827,9 +6852,9 @@
       "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
     },
     "length-prefixed-message": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/length-prefixed-message/-/length-prefixed-message-3.0.3.tgz",
-      "integrity": "sha1-JFR01pq8BhTco2jcNaqAdJgqI6w=",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/length-prefixed-message/-/length-prefixed-message-3.0.4.tgz",
+      "integrity": "sha512-Tqyx4nggb9nkLD6p4hyIz7UiVNg5u3OnCP2h0hS/HXpheH88rsoNEgNB8xTnpPMw6zWXGZ7Cpg1zhWPlsJ0/TQ==",
       "requires": {
         "varint": "^3.0.1"
       },
@@ -7103,6 +7128,14 @@
         "phin": "^2.9.1",
         "xhr": "^2.0.1",
         "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+          "dev": true
+        }
       }
     },
     "load-json-file": {
@@ -7127,9 +7160,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.assign": {
       "version": "4.2.0",
@@ -7496,9 +7529,9 @@
       }
     },
     "mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+      "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
     },
     "mime-db": {
       "version": "1.40.0",
@@ -7689,9 +7722,9 @@
       "integrity": "sha512-PZM4dhYFmCF6uZGWpEmoPMUqJBywS9IcAgybT2GmSpYI1BvGvoWSdbio+ik+q/YD2vodhvslESWIS3NnkKYdqQ=="
     },
     "multiserver": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/multiserver/-/multiserver-3.3.6.tgz",
-      "integrity": "sha512-zuPjEaPEVMosWXnfNalXv3QyjYCwaD2emC6l/ozwMeaCcZ/Do7WMb/ZF8MC6TVwhV9Y7eTcnBiYEP/hq8zA2nA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/multiserver/-/multiserver-3.4.0.tgz",
+      "integrity": "sha512-HSGnZBXDM9e8gi3YyhObwiDYP3BFeL+TV22H1dAReigHHMc52IDBsz9N1OR72OKxCd7SMD+gKBpVJbJohhb3og==",
       "requires": {
         "debug": "^4.1.1",
         "multicb": "^1.2.2",
@@ -7888,9 +7921,9 @@
       "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M="
     },
     "nearley": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.16.0.tgz",
-      "integrity": "sha512-Tr9XD3Vt/EujXbZBv6UAHYoLUSMQAxSsTnm9K3koXzjzNWY195NqALeyrzLZBKzAkL3gl92BcSogqrHjD8QuUg==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.18.0.tgz",
+      "integrity": "sha512-/zQOMCeJcioI0xJtd5RpBiWw2WP7wLe6vq8/3Yu0rEwgus/G/+pViX80oA87JdVgjRt2895mZSv2VfZmy4W1uw==",
       "requires": {
         "commander": "^2.19.0",
         "moo": "^0.4.3",
@@ -7915,9 +7948,9 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "node-abi": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.9.0.tgz",
-      "integrity": "sha512-jmEOvv0eanWjhX8dX1pmjb7oJl1U1oR4FOh0b2GnvALwSYoOdU7sj+kLDSAyjo4pfC9aj/IxkloxdLJQhSSQBA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.10.0.tgz",
+      "integrity": "sha512-OT0WepUvYHXdki6DU8LWhEkuo3M44i2paWBYtH9qXtPb9YiKlYEKa5WUII20XEcOv7UJPzfB0kZfPZdW46zdkw==",
       "requires": {
         "semver": "^5.4.1"
       }
@@ -7925,7 +7958,8 @@
     "node-gyp-build": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.9.0.tgz",
-      "integrity": "sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A=="
+      "integrity": "sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A==",
+      "optional": true
     },
     "non-private-ip": {
       "version": "1.4.4",
@@ -8163,9 +8197,9 @@
       }
     },
     "omggif": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.9.tgz",
-      "integrity": "sha1-3LcCTazVDFK00wPwSALJHAV8dl8=",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
+      "integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==",
       "dev": true
     },
     "on-change-network": {
@@ -8312,21 +8346,21 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "package-json": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.4.0.tgz",
-      "integrity": "sha512-bd1T8OBG7hcvMd9c/udgv6u5v9wISP3Oyl9Cm7Weop8EFwrtcQDnS2sb6zhwqus2WslSr5wSTIPiTTpxxmPm7Q==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
+      "integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
       "dev": true,
       "requires": {
         "got": "^9.6.0",
-        "registry-auth-token": "^3.4.0",
+        "registry-auth-token": "^4.0.0",
         "registry-url": "^5.0.0",
-        "semver": "^6.1.1"
+        "semver": "^6.2.0"
       },
       "dependencies": {
         "semver": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
-          "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==",
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
       }
@@ -9532,9 +9566,9 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.2.0.tgz",
-      "integrity": "sha512-GEn74ZffufCmkDDLNcl3uuyF/aSD6exEyh1v/ZSdAomB82t6G9hzJVRx0jBmLDW+VfZqks3aScmMw9DszwUalA=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.3.0.tgz",
+      "integrity": "sha512-avHdspHO+9rQTLbv1RO+MPYeP/SzsCoxofjVnHanETfQhTJrmB0HlDoW+EiN/R+C0BZ+gERab9NY0lPN2TxNag=="
     },
     "pubsub-js": {
       "version": "1.7.0",
@@ -9869,9 +9903,9 @@
       }
     },
     "pull-stream": {
-      "version": "3.6.13",
-      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.13.tgz",
-      "integrity": "sha512-enbnbnO+czsPuCq9s9HTTzDzzVQD5TSe60aO3nBioeJ9mevh8RzE4Hxbujo9TReg1fJlmNEL8uyQTUgn8+rSHg=="
+      "version": "3.6.14",
+      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.14.tgz",
+      "integrity": "sha512-KIqdvpqHHaTUA2mCYcLG1ibEbu/LCKoJZsBWyv9lSYtPkJPBq8m3Hxa103xHi6D2thj5YXa0TqK3L3GUkwgnew=="
     },
     "pull-through": {
       "version": "1.0.18",
@@ -10120,9 +10154,9 @@
       }
     },
     "react-is": {
-      "version": "16.8.6",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
-      "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
+      "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==",
       "dev": true
     },
     "read-chunk": {
@@ -10263,10 +10297,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
-      "dev": true
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "regex-cache": {
       "version": "0.4.4",
@@ -10292,12 +10325,12 @@
       "dev": true
     },
     "registry-auth-token": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
-      "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.0.0.tgz",
+      "integrity": "sha512-lpQkHxd9UL6tb3k/aHAVfnVtn+Bcs9ob5InuFLLEDqSqeq+AljB8GZW9xY0x7F+xYwEcjKe07nyoxzEYz6yvkw==",
       "dev": true,
       "requires": {
-        "rc": "^1.1.6",
+        "rc": "^1.2.8",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -10615,6 +10648,12 @@
           "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.1.2.tgz",
           "integrity": "sha1-E1uZLAV1yYXPoPSUoyJ+0jhYPs4=",
           "dev": true
+        },
+        "mime": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+          "dev": true
         }
       }
     },
@@ -10695,6 +10734,11 @@
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
       "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q=="
     },
+    "run-series": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.8.tgz",
+      "integrity": "sha512-+GztYEPRpIsQoCSraWHDBs9WVy4eVME16zhOtDB4H9J4xN0XRhknnmLOl+4gRgZtu8dpp9N/utSPjKH/xmDzXg=="
+    },
     "rusha": {
       "version": "0.8.13",
       "resolved": "https://registry.npmjs.org/rusha/-/rusha-0.8.13.tgz",
@@ -10740,9 +10784,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sanitize-filename": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.1.tgz",
-      "integrity": "sha1-YS2hyWRz+gLczaktzVtKsWSmdyo=",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.2.tgz",
+      "integrity": "sha512-cmTzND7RMxUB+f7gI+4+KAVHWEg0lfXvQJdko+FXDP5bNbGIdx4KMP5pX6lv5jfT9jSf6OBbjyxjFtZQwYA/ig==",
       "dev": true,
       "requires": {
         "truncate-utf8-bytes": "^1.0.0"
@@ -10943,6 +10987,11 @@
         "pull-stream": "^3.4.5"
       }
     },
+    "secret-stack-decorators": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/secret-stack-decorators/-/secret-stack-decorators-1.0.0.tgz",
+      "integrity": "sha512-IOg/RCXS6q5rRuGPV0fsExG5D5wGVk+evvPl0pdZJrfBwDQiWGi4yxPhDNxvZb/So4TiVj8iQRxVdkWwrPFaBg=="
+    },
     "secrets.js-grempe": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/secrets.js-grempe/-/secrets.js-grempe-1.1.0.tgz",
@@ -11094,9 +11143,9 @@
           }
         },
         "semver": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
-          "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==",
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
       }
@@ -11167,6 +11216,14 @@
       "dev": true,
       "requires": {
         "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+          "dev": true
+        }
       }
     },
     "single-line-log": {
@@ -11327,9 +11384,9 @@
       }
     },
     "sodium-browserify": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/sodium-browserify/-/sodium-browserify-1.2.7.tgz",
-      "integrity": "sha512-PGhNO8KravjroRDYvurMPRYi4xMM7zjTW10R77Nq9sjkU314YA2sPeXS6UA5k/rLHaXLaZ6YfLLVz+DdCU5w0g==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sodium-browserify/-/sodium-browserify-1.3.0.tgz",
+      "integrity": "sha512-1KRS6Oew3X13AIZhbmGF0YBdt2pQdafJMfv83OZHWbzxG92YBBnN8HYx/VKmYB4xCe90eidNaDJWBEFw/o3ahw==",
       "requires": {
         "libsodium-wrappers": "^0.7.4",
         "sha.js": "2.4.5",
@@ -11382,13 +11439,20 @@
       }
     },
     "sodium-native": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-2.4.2.tgz",
-      "integrity": "sha512-qwHcUnzFpRSGSm6F49j/h5SnxPFBgSNdDwZkAqjvuAoHQIVBFOXYb+oCUTJV80K5hRqSYCihpbX06vbrtPbilg==",
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-2.4.6.tgz",
+      "integrity": "sha512-Ro9lhTjot8M01nwKLXiqLSmjR7B8o+Wg4HmJUjEShw/q6XPlNMzjPkA1VJKaMH8SO8fJ/sggAKVwreTaFszS2Q==",
       "requires": {
         "ini": "^1.3.5",
-        "nan": "^2.4.0",
-        "node-gyp-build": "^3.0.0"
+        "nan": "^2.14.0",
+        "node-gyp-build": "^4.1.0"
+      },
+      "dependencies": {
+        "node-gyp-build": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.1.0.tgz",
+          "integrity": "sha512-rGLv++nK20BG8gc0MzzcYe1Nl3p3mtwJ74Q2QD0HTEDKZ6NvOFSelY6s2QBPWIHRR8h7hpad0LiwajfClBJfNg=="
+        }
       }
     },
     "sodium-universal": {
@@ -11935,9 +11999,9 @@
       }
     },
     "ssb-config": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/ssb-config/-/ssb-config-3.3.1.tgz",
-      "integrity": "sha512-HipnCSEwj/Urjq4KIVVwf1bpaYgvz+4Wn2pi+d1403JMZ2pU+LzjW6Taf2td5XE1Nu/wgnunAIq5UUqPJ7mx6g==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/ssb-config/-/ssb-config-3.3.2.tgz",
+      "integrity": "sha512-EUOp8QbFgCqy6RzNgLqoTqI+jtpBi3AHUwAymR3jHGbgc3DqCMnvGCHt7My8m15LA88oyeDjrzNNJsLfbVyTZQ==",
       "requires": {
         "deep-extend": "^0.6.0",
         "lodash.get": "^4.4.2",
@@ -11946,6 +12010,49 @@
         "rc": "^1.1.6",
         "ssb-caps": "^1.0.1",
         "ssb-keys": "^7.1.4"
+      }
+    },
+    "ssb-conn-db": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ssb-conn-db/-/ssb-conn-db-0.1.0.tgz",
+      "integrity": "sha512-mzRZv1IKPcnDpJndr4HsvJ/EBA1Bb849y+DjOwgvP0Vsk0R0bkhyNqmUHIrUTeJX8jkyeuiVXc6iYAIKqOYNmA==",
+      "requires": {
+        "atomic-file": "^1.1.5",
+        "debug": "~4.1.1",
+        "multiserver-address": "~1.0.1",
+        "pull-notify": "~0.1.1",
+        "ssb-ref": "~2.13.9"
+      },
+      "dependencies": {
+        "atomic-file": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/atomic-file/-/atomic-file-1.1.5.tgz",
+          "integrity": "sha512-TG+5YFiaKQ6CZiSQsosGMJ/IJzwMZ4V/rSdEXlD6+DwKyv8OyeUcprq34kp4yuS6bfQYXhxBC2Vm8PWo+iKBGQ=="
+        }
+      }
+    },
+    "ssb-conn-hub": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/ssb-conn-hub/-/ssb-conn-hub-0.0.3.tgz",
+      "integrity": "sha512-F/5XtjFObCK9VCEKMoKoS0xoFGuV2AM+wU4+4GJCR7SUz3ZqNj8ik9Qu4esDSqsv2Q2JFSeupcO8d0Tqt6lWlw==",
+      "requires": {
+        "debug": "^4.1.1",
+        "multiserver-address": "~1.0.1",
+        "promisify-tuple": "^1.0.0",
+        "pull-notify": "~0.1.1",
+        "ssb-ref": "~2.13.9"
+      }
+    },
+    "ssb-conn-staging": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/ssb-conn-staging/-/ssb-conn-staging-0.0.1.tgz",
+      "integrity": "sha512-4iOxScdLWy6kAAtfIv7C7TiHqtZFgg+cdJt66peXx3MrfLqMDy657DFe5C2neTD4N63MIlysplkmtXYQzTusRg==",
+      "requires": {
+        "debug": "^4.1.1",
+        "multiserver-address": "~1.0.1",
+        "pull-notify": "~0.1.1",
+        "pull-stream": "^3.6.9",
+        "ssb-conn-hub": "~0.0.3"
       }
     },
     "ssb-dark-crystal-schema": {
@@ -12251,13 +12358,26 @@
       }
     },
     "ssb-keys": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.1.7.tgz",
-      "integrity": "sha512-Zncn++gtpoF4Wjz/po4Jvt7mCHbQfU6ATljahqf1CprWAio4JBUJnQrUeUlmlTn3f4Tseo0/hoh3vk7Bu6M/Sw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.2.0.tgz",
+      "integrity": "sha512-qxbVBYB5CsxWPEFg6qe+98hL6Jbs0rztA5zYsoQmYqz2+j3EhhIuXMTki92K4xREOCA2x45FFdOjDFy7ReDpBA==",
       "requires": {
         "chloride": "^2.2.8",
         "mkdirp": "~0.5.0",
         "private-box": "^0.3.0"
+      }
+    },
+    "ssb-lan": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ssb-lan/-/ssb-lan-0.1.1.tgz",
+      "integrity": "sha512-CnN4NK4mXa3zViEP63VxcNY/0+cVR+sLs1FAavY2b9vZS0NYf8Qc1uVxZKcJ5ERuSg1NNGbPeg8sOuXYAW4EjA==",
+      "requires": {
+        "broadcast-stream": "^0.2.2",
+        "debug": "^4.1.1",
+        "pull-notify": "~0.1.1",
+        "secret-stack-decorators": "~1.0.0",
+        "ssb-keys": "^7.2.0",
+        "ssb-ref": "^2.13.9"
       }
     },
     "ssb-legacy-conn": {
@@ -12279,49 +12399,6 @@
         "ssb-conn-staging": "0.0.1",
         "ssb-ref": "^2.13.9",
         "statistics": "^3.3.0"
-      },
-      "dependencies": {
-        "atomic-file": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/atomic-file/-/atomic-file-1.1.5.tgz",
-          "integrity": "sha512-TG+5YFiaKQ6CZiSQsosGMJ/IJzwMZ4V/rSdEXlD6+DwKyv8OyeUcprq34kp4yuS6bfQYXhxBC2Vm8PWo+iKBGQ=="
-        },
-        "ssb-conn-db": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/ssb-conn-db/-/ssb-conn-db-0.1.0.tgz",
-          "integrity": "sha512-mzRZv1IKPcnDpJndr4HsvJ/EBA1Bb849y+DjOwgvP0Vsk0R0bkhyNqmUHIrUTeJX8jkyeuiVXc6iYAIKqOYNmA==",
-          "requires": {
-            "atomic-file": "^1.1.5",
-            "debug": "~4.1.1",
-            "multiserver-address": "~1.0.1",
-            "pull-notify": "~0.1.1",
-            "ssb-ref": "~2.13.9"
-          }
-        },
-        "ssb-conn-hub": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/ssb-conn-hub/-/ssb-conn-hub-0.0.3.tgz",
-          "integrity": "sha512-F/5XtjFObCK9VCEKMoKoS0xoFGuV2AM+wU4+4GJCR7SUz3ZqNj8ik9Qu4esDSqsv2Q2JFSeupcO8d0Tqt6lWlw==",
-          "requires": {
-            "debug": "^4.1.1",
-            "multiserver-address": "~1.0.1",
-            "promisify-tuple": "^1.0.0",
-            "pull-notify": "~0.1.1",
-            "ssb-ref": "~2.13.9"
-          }
-        },
-        "ssb-conn-staging": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/ssb-conn-staging/-/ssb-conn-staging-0.0.1.tgz",
-          "integrity": "sha512-4iOxScdLWy6kAAtfIv7C7TiHqtZFgg+cdJt66peXx3MrfLqMDy657DFe5C2neTD4N63MIlysplkmtXYQzTusRg==",
-          "requires": {
-            "debug": "^4.1.1",
-            "multiserver-address": "~1.0.1",
-            "pull-notify": "~0.1.1",
-            "pull-stream": "^3.6.9",
-            "ssb-conn-hub": "~0.0.3"
-          }
-        }
       }
     },
     "ssb-local": {
@@ -12644,9 +12721,9 @@
       }
     },
     "ssb-server": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/ssb-server/-/ssb-server-15.0.2.tgz",
-      "integrity": "sha512-xY3H+E3P5vSQREtoBohUT/1Lhx01NNTkooud29h+fhwXX1+Erowds/b0M+HpVpVClY8/yR4/0jATBg0oKvD+VA==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/ssb-server/-/ssb-server-15.1.0.tgz",
+      "integrity": "sha512-4qn3Q+xpKL6BKBTgO1dHSt5ljyrZkWVoHYaZzCYbs75rGbaGvc0evSyu2TpaYwiiSxrVxJGYr8s4MyXzdPqUVQ==",
       "requires": {
         "bash-color": "~0.0.3",
         "broadcast-stream": "^0.2.1",
@@ -12673,7 +12750,7 @@
         "pull-pushable": "^2.2.0",
         "pull-stream": "^3.6.2",
         "rimraf": "^2.4.2",
-        "secret-stack": "^6.0.2",
+        "secret-stack": "^6.2.1",
         "ssb-blobs": "1.2.1",
         "ssb-caps": "^1.0.1",
         "ssb-client": "^4.7.5",
@@ -14122,487 +14199,6 @@
           "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
-        "fsevents": {
-          "version": "1.2.9",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-          "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
-          "optional": true,
-          "requires": {
-            "nan": "^2.12.1",
-            "node-pre-gyp": "^0.12.0"
-          },
-          "dependencies": {
-            "abbrev": {
-              "version": "1.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "ansi-regex": {
-              "version": "2.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "aproba": {
-              "version": "1.2.0",
-              "bundled": true,
-              "optional": true
-            },
-            "are-we-there-yet": {
-              "version": "1.1.5",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
-              }
-            },
-            "balanced-match": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "brace-expansion": {
-              "version": "1.1.11",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-              }
-            },
-            "chownr": {
-              "version": "1.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "code-point-at": {
-              "version": "1.1.0",
-              "bundled": true,
-              "optional": true
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "console-control-strings": {
-              "version": "1.1.0",
-              "bundled": true,
-              "optional": true
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "debug": {
-              "version": "4.1.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            },
-            "deep-extend": {
-              "version": "0.6.0",
-              "bundled": true,
-              "optional": true
-            },
-            "delegates": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "detect-libc": {
-              "version": "1.0.3",
-              "bundled": true,
-              "optional": true
-            },
-            "fs-minipass": {
-              "version": "1.2.5",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "minipass": "^2.2.1"
-              }
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "gauge": {
-              "version": "2.7.4",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
-              }
-            },
-            "glob": {
-              "version": "7.1.3",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            },
-            "has-unicode": {
-              "version": "2.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "iconv-lite": {
-              "version": "0.4.24",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "safer-buffer": ">= 2.1.2 < 3"
-              }
-            },
-            "ignore-walk": {
-              "version": "3.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "minimatch": "^3.0.4"
-              }
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true,
-              "optional": true
-            },
-            "ini": {
-              "version": "1.3.5",
-              "bundled": true,
-              "optional": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "brace-expansion": "^1.1.7"
-              }
-            },
-            "minimist": {
-              "version": "0.0.8",
-              "bundled": true,
-              "optional": true
-            },
-            "minipass": {
-              "version": "2.3.5",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.0"
-              }
-            },
-            "minizlib": {
-              "version": "1.2.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "minipass": "^2.2.1"
-              }
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "minimist": "0.0.8"
-              }
-            },
-            "ms": {
-              "version": "2.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "needle": {
-              "version": "2.3.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "debug": "^4.1.0",
-                "iconv-lite": "^0.4.4",
-                "sax": "^1.2.4"
-              }
-            },
-            "node-pre-gyp": {
-              "version": "0.12.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "detect-libc": "^1.0.2",
-                "mkdirp": "^0.5.1",
-                "needle": "^2.2.1",
-                "nopt": "^4.0.1",
-                "npm-packlist": "^1.1.6",
-                "npmlog": "^4.0.2",
-                "rc": "^1.2.7",
-                "rimraf": "^2.6.1",
-                "semver": "^5.3.0",
-                "tar": "^4"
-              }
-            },
-            "nopt": {
-              "version": "4.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "abbrev": "1",
-                "osenv": "^0.1.4"
-              }
-            },
-            "npm-bundled": {
-              "version": "1.0.6",
-              "bundled": true,
-              "optional": true
-            },
-            "npm-packlist": {
-              "version": "1.4.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "ignore-walk": "^3.0.1",
-                "npm-bundled": "^1.0.1"
-              }
-            },
-            "npmlog": {
-              "version": "4.1.2",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
-              }
-            },
-            "number-is-nan": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "once": {
-              "version": "1.4.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "wrappy": "1"
-              }
-            },
-            "os-homedir": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "os-tmpdir": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "osenv": {
-              "version": "0.1.5",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.0"
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "process-nextick-args": {
-              "version": "2.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "rc": {
-              "version": "1.2.8",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "deep-extend": "^0.6.0",
-                "ini": "~1.3.0",
-                "minimist": "^1.2.0",
-                "strip-json-comments": "~2.0.1"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "rimraf": {
-              "version": "2.6.3",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "glob": "^7.1.3"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.2",
-              "bundled": true,
-              "optional": true
-            },
-            "safer-buffer": {
-              "version": "2.1.2",
-              "bundled": true,
-              "optional": true
-            },
-            "sax": {
-              "version": "1.2.4",
-              "bundled": true,
-              "optional": true
-            },
-            "semver": {
-              "version": "5.7.0",
-              "bundled": true,
-              "optional": true
-            },
-            "set-blocking": {
-              "version": "2.0.0",
-              "bundled": true,
-              "optional": true
-            },
-            "signal-exit": {
-              "version": "3.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              }
-            },
-            "strip-json-comments": {
-              "version": "2.0.1",
-              "bundled": true,
-              "optional": true
-            },
-            "tar": {
-              "version": "4.4.8",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "chownr": "^1.1.1",
-                "fs-minipass": "^1.2.5",
-                "minipass": "^2.3.4",
-                "minizlib": "^1.1.1",
-                "mkdirp": "^0.5.0",
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.2"
-              }
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "wide-align": {
-              "version": "1.1.3",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "string-width": "^1.0.2 || 2"
-              }
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "yallist": {
-              "version": "3.0.3",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
         "function-bind": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -15224,9 +14820,9 @@
           },
           "dependencies": {
             "readable-stream": {
-              "version": "3.4.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-              "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+              "version": "3.3.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+              "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
               "requires": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -15964,12 +15560,12 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
               "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
             },
             "append-transform": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
               "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
               "requires": {
                 "default-require-extensions": "^2.0.0"
@@ -15977,22 +15573,22 @@
             },
             "archy": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
               "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
             },
             "arrify": {
               "version": "1.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
               "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
             },
             "balanced-match": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
               "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
             },
             "brace-expansion": {
               "version": "1.1.11",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
               "requires": {
                 "balanced-match": "^1.0.0",
@@ -16001,7 +15597,7 @@
             },
             "caching-transform": {
               "version": "3.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-3.0.1.tgz",
               "integrity": "sha512-Y1KTLNwSPd4ljsDrFOtyXVmm7Gnk42yQitNq43AhE+cwUR/e4T+rmOHs1IPtzBg8066GBJfTOj1rQYFSWSsH2g==",
               "requires": {
                 "hasha": "^3.0.0",
@@ -16012,12 +15608,12 @@
             },
             "camelcase": {
               "version": "5.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
               "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
             },
             "cliui": {
               "version": "4.1.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
               "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
               "requires": {
                 "string-width": "^2.1.1",
@@ -16027,22 +15623,22 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
               "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
             },
             "commondir": {
               "version": "1.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
               "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
             },
             "concat-map": {
               "version": "0.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
               "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
             },
             "convert-source-map": {
               "version": "1.6.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
               "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
               "requires": {
                 "safe-buffer": "~5.1.1"
@@ -16050,7 +15646,7 @@
             },
             "cross-spawn": {
               "version": "4.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
               "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
               "requires": {
                 "lru-cache": "^4.0.1",
@@ -16059,7 +15655,7 @@
             },
             "debug": {
               "version": "4.1.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
               "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
               "requires": {
                 "ms": "^2.1.1"
@@ -16067,12 +15663,12 @@
             },
             "decamelize": {
               "version": "1.2.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
               "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
             },
             "default-require-extensions": {
               "version": "2.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
               "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
               "requires": {
                 "strip-bom": "^3.0.0"
@@ -16080,7 +15676,7 @@
             },
             "end-of-stream": {
               "version": "1.4.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
               "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
               "requires": {
                 "once": "^1.4.0"
@@ -16088,7 +15684,7 @@
             },
             "error-ex": {
               "version": "1.3.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
               "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
               "requires": {
                 "is-arrayish": "^0.2.1"
@@ -16096,12 +15692,12 @@
             },
             "es6-error": {
               "version": "4.1.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
               "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
             },
             "execa": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
               "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
               "requires": {
                 "cross-spawn": "^6.0.0",
@@ -16115,7 +15711,7 @@
               "dependencies": {
                 "cross-spawn": {
                   "version": "6.0.5",
-                  "resolved": false,
+                  "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
                   "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
                   "requires": {
                     "nice-try": "^1.0.4",
@@ -16129,7 +15725,7 @@
             },
             "find-cache-dir": {
               "version": "2.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.0.0.tgz",
               "integrity": "sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==",
               "requires": {
                 "commondir": "^1.0.1",
@@ -16139,7 +15735,7 @@
             },
             "find-up": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
               "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
               "requires": {
                 "locate-path": "^3.0.0"
@@ -16147,7 +15743,7 @@
             },
             "foreground-child": {
               "version": "1.5.6",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
               "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
               "requires": {
                 "cross-spawn": "^4",
@@ -16156,17 +15752,17 @@
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
               "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
             },
             "get-caller-file": {
               "version": "1.0.3",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
               "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
             },
             "get-stream": {
               "version": "4.1.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
               "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
               "requires": {
                 "pump": "^3.0.0"
@@ -16174,7 +15770,7 @@
             },
             "glob": {
               "version": "7.1.3",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
               "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
               "requires": {
                 "fs.realpath": "^1.0.0",
@@ -16187,17 +15783,17 @@
             },
             "graceful-fs": {
               "version": "4.1.15",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
               "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
             },
             "has-flag": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
               "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
             },
             "hasha": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
               "integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
               "requires": {
                 "is-stream": "^1.0.1"
@@ -16205,17 +15801,17 @@
             },
             "hosted-git-info": {
               "version": "2.7.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
               "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
             },
             "imurmurhash": {
               "version": "0.1.4",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
               "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
             },
             "inflight": {
               "version": "1.0.6",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
               "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
               "requires": {
                 "once": "^1.3.0",
@@ -16224,42 +15820,42 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
             },
             "invert-kv": {
               "version": "2.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
               "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
             },
             "is-arrayish": {
               "version": "0.2.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
               "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
             },
             "is-stream": {
               "version": "1.1.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
               "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
             },
             "isexe": {
               "version": "2.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
               "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
             },
             "istanbul-lib-coverage": {
               "version": "2.0.3",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
               "integrity": "sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw=="
             },
             "istanbul-lib-hook": {
               "version": "2.0.3",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.3.tgz",
               "integrity": "sha512-CLmEqwEhuCYtGcpNVJjLV1DQyVnIqavMLFHV/DP+np/g3qvdxu3gsPqYoJMXm15sN84xOlckFB3VNvRbf5yEgA==",
               "requires": {
                 "append-transform": "^1.0.0"
@@ -16267,7 +15863,7 @@
             },
             "istanbul-lib-report": {
               "version": "2.0.4",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.4.tgz",
               "integrity": "sha512-sOiLZLAWpA0+3b5w5/dq0cjm2rrNdAfHWaGhmn7XEFW6X++IV9Ohn+pnELAl9K3rfpaeBfbmH9JU5sejacdLeA==",
               "requires": {
                 "istanbul-lib-coverage": "^2.0.3",
@@ -16277,7 +15873,7 @@
               "dependencies": {
                 "supports-color": {
                   "version": "6.1.0",
-                  "resolved": false,
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
                   "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
                   "requires": {
                     "has-flag": "^3.0.0"
@@ -16287,7 +15883,7 @@
             },
             "istanbul-lib-source-maps": {
               "version": "3.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.2.tgz",
               "integrity": "sha512-JX4v0CiKTGp9fZPmoxpu9YEkPbEqCqBbO3403VabKjH+NRXo72HafD5UgnjTEqHL2SAjaZK1XDuDOkn6I5QVfQ==",
               "requires": {
                 "debug": "^4.1.1",
@@ -16299,14 +15895,14 @@
               "dependencies": {
                 "source-map": {
                   "version": "0.6.1",
-                  "resolved": false,
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
                   "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
                 }
               }
             },
             "istanbul-reports": {
               "version": "2.1.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.1.1.tgz",
               "integrity": "sha512-FzNahnidyEPBCI0HcufJoSEoKykesRlFcSzQqjH9x0+LC8tnnE/p/90PBLu8iZTxr8yYZNyTtiAujUqyN+CIxw==",
               "requires": {
                 "handlebars": "^4.1.0"
@@ -16314,12 +15910,12 @@
             },
             "json-parse-better-errors": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
               "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
             },
             "lcid": {
               "version": "2.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
               "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
               "requires": {
                 "invert-kv": "^2.0.0"
@@ -16327,7 +15923,7 @@
             },
             "load-json-file": {
               "version": "4.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
               "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
               "requires": {
                 "graceful-fs": "^4.1.2",
@@ -16338,7 +15934,7 @@
             },
             "locate-path": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
               "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
               "requires": {
                 "p-locate": "^3.0.0",
@@ -16347,12 +15943,12 @@
             },
             "lodash.flattendeep": {
               "version": "4.4.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
               "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
             },
             "lru-cache": {
               "version": "4.1.5",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
               "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
               "requires": {
                 "pseudomap": "^1.0.2",
@@ -16361,7 +15957,7 @@
             },
             "make-dir": {
               "version": "1.3.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
               "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
               "requires": {
                 "pify": "^3.0.0"
@@ -16369,7 +15965,7 @@
             },
             "map-age-cleaner": {
               "version": "0.1.3",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
               "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
               "requires": {
                 "p-defer": "^1.0.0"
@@ -16377,7 +15973,7 @@
             },
             "mem": {
               "version": "4.1.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
               "integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
               "requires": {
                 "map-age-cleaner": "^0.1.1",
@@ -16387,7 +15983,7 @@
             },
             "merge-source-map": {
               "version": "1.1.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
               "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
               "requires": {
                 "source-map": "^0.6.1"
@@ -16395,19 +15991,19 @@
               "dependencies": {
                 "source-map": {
                   "version": "0.6.1",
-                  "resolved": false,
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
                   "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
                 }
               }
             },
             "mimic-fn": {
               "version": "1.2.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
               "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
             },
             "minimatch": {
               "version": "3.0.4",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "requires": {
                 "brace-expansion": "^1.1.7"
@@ -16415,7 +16011,7 @@
             },
             "mkdirp": {
               "version": "0.5.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "requires": {
                 "minimist": "0.0.8"
@@ -16423,24 +16019,24 @@
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "resolved": false,
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                   "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
                 }
               }
             },
             "ms": {
               "version": "2.1.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
               "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
             },
             "nice-try": {
               "version": "1.0.5",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
               "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
             },
             "normalize-package-data": {
               "version": "2.5.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
               "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
               "requires": {
                 "hosted-git-info": "^2.1.4",
@@ -16451,7 +16047,7 @@
             },
             "npm-run-path": {
               "version": "2.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
               "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
               "requires": {
                 "path-key": "^2.0.0"
@@ -16459,12 +16055,12 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
               "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
             },
             "once": {
               "version": "1.4.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "requires": {
                 "wrappy": "1"
@@ -16472,12 +16068,12 @@
             },
             "os-homedir": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
               "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
             },
             "os-locale": {
               "version": "3.1.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
               "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
               "requires": {
                 "execa": "^1.0.0",
@@ -16487,22 +16083,22 @@
             },
             "p-defer": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
               "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
             },
             "p-finally": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
               "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
             },
             "p-is-promise": {
               "version": "2.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
               "integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg=="
             },
             "p-limit": {
               "version": "2.1.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
               "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
               "requires": {
                 "p-try": "^2.0.0"
@@ -16510,7 +16106,7 @@
             },
             "p-locate": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
               "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
               "requires": {
                 "p-limit": "^2.0.0"
@@ -16518,12 +16114,12 @@
             },
             "p-try": {
               "version": "2.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
               "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
             },
             "package-hash": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-3.0.0.tgz",
               "integrity": "sha512-lOtmukMDVvtkL84rJHI7dpTYq+0rli8N2wlnqUcBuDWCfVhRUfOmnR9SsoHFMLpACvEV60dX7rd0rFaYDZI+FA==",
               "requires": {
                 "graceful-fs": "^4.1.15",
@@ -16534,7 +16130,7 @@
             },
             "parse-json": {
               "version": "4.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
               "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
               "requires": {
                 "error-ex": "^1.3.1",
@@ -16543,27 +16139,27 @@
             },
             "path-exists": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
               "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
               "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
             },
             "path-key": {
               "version": "2.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
               "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
             },
             "path-parse": {
               "version": "1.0.6",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
               "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
             },
             "path-type": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
               "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
               "requires": {
                 "pify": "^3.0.0"
@@ -16571,12 +16167,12 @@
             },
             "pify": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
               "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
             },
             "pkg-dir": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
               "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
               "requires": {
                 "find-up": "^3.0.0"
@@ -16584,12 +16180,12 @@
             },
             "pseudomap": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
               "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
             },
             "pump": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
               "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
               "requires": {
                 "end-of-stream": "^1.1.0",
@@ -16598,7 +16194,7 @@
             },
             "read-pkg": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
               "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
               "requires": {
                 "load-json-file": "^4.0.0",
@@ -16608,7 +16204,7 @@
             },
             "read-pkg-up": {
               "version": "4.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
               "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
               "requires": {
                 "find-up": "^3.0.0",
@@ -16617,7 +16213,7 @@
             },
             "release-zalgo": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
               "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
               "requires": {
                 "es6-error": "^4.0.1"
@@ -16625,17 +16221,17 @@
             },
             "require-directory": {
               "version": "2.1.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
               "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
             },
             "require-main-filename": {
               "version": "1.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
               "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
             },
             "resolve": {
               "version": "1.10.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
               "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
               "requires": {
                 "path-parse": "^1.0.6"
@@ -16643,12 +16239,12 @@
             },
             "resolve-from": {
               "version": "4.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
               "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
             },
             "rimraf": {
               "version": "2.6.3",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
               "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
               "requires": {
                 "glob": "^7.1.3"
@@ -16656,22 +16252,22 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
               "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
             },
             "semver": {
               "version": "5.6.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
               "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
             },
             "set-blocking": {
               "version": "2.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
               "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
             },
             "shebang-command": {
               "version": "1.2.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
               "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
               "requires": {
                 "shebang-regex": "^1.0.0"
@@ -16679,17 +16275,17 @@
             },
             "shebang-regex": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
               "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
             },
             "signal-exit": {
               "version": "3.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
               "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
             },
             "spawn-wrap": {
               "version": "1.4.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
               "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
               "requires": {
                 "foreground-child": "^1.5.6",
@@ -16702,7 +16298,7 @@
             },
             "spdx-correct": {
               "version": "3.1.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
               "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
               "requires": {
                 "spdx-expression-parse": "^3.0.0",
@@ -16711,12 +16307,12 @@
             },
             "spdx-exceptions": {
               "version": "2.2.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
               "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
             },
             "spdx-expression-parse": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
               "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
               "requires": {
                 "spdx-exceptions": "^2.1.0",
@@ -16725,12 +16321,12 @@
             },
             "spdx-license-ids": {
               "version": "3.0.3",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
               "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g=="
             },
             "string-width": {
               "version": "2.1.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
               "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
               "requires": {
                 "is-fullwidth-code-point": "^2.0.0",
@@ -16739,7 +16335,7 @@
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "requires": {
                 "ansi-regex": "^3.0.0"
@@ -16747,17 +16343,17 @@
             },
             "strip-bom": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
               "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
             },
             "strip-eof": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
               "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
             },
             "test-exclude": {
               "version": "5.1.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.1.0.tgz",
               "integrity": "sha512-gwf0S2fFsANC55fSeSqpb8BYk6w3FDvwZxfNjeF6FRgvFa43r+7wRiA/Q0IxoRU37wB/LE8IQ4221BsNucTaCA==",
               "requires": {
                 "arrify": "^1.0.1",
@@ -16768,12 +16364,12 @@
             },
             "uuid": {
               "version": "3.3.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
               "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
             },
             "validate-npm-package-license": {
               "version": "3.0.4",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
               "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
               "requires": {
                 "spdx-correct": "^3.0.0",
@@ -16782,7 +16378,7 @@
             },
             "which": {
               "version": "1.3.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
               "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
               "requires": {
                 "isexe": "^2.0.0"
@@ -16790,12 +16386,12 @@
             },
             "which-module": {
               "version": "2.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
               "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
             },
             "wrap-ansi": {
               "version": "2.1.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
               "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
               "requires": {
                 "string-width": "^1.0.1",
@@ -16804,12 +16400,12 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.1.1",
-                  "resolved": false,
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                   "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
                 },
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
-                  "resolved": false,
+                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                   "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                   "requires": {
                     "number-is-nan": "^1.0.0"
@@ -16817,7 +16413,7 @@
                 },
                 "string-width": {
                   "version": "1.0.2",
-                  "resolved": false,
+                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                   "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                   "requires": {
                     "code-point-at": "^1.0.0",
@@ -16827,7 +16423,7 @@
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "resolved": false,
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "requires": {
                     "ansi-regex": "^2.0.0"
@@ -16837,12 +16433,12 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
               "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
             },
             "write-file-atomic": {
               "version": "2.4.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.2.tgz",
               "integrity": "sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==",
               "requires": {
                 "graceful-fs": "^4.1.11",
@@ -16852,17 +16448,17 @@
             },
             "y18n": {
               "version": "4.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
               "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
             },
             "yallist": {
               "version": "2.1.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
               "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
             },
             "yargs": {
               "version": "12.0.5",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
               "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
               "requires": {
                 "cliui": "^4.0.0",
@@ -16881,7 +16477,7 @@
             },
             "yargs-parser": {
               "version": "11.1.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
               "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
               "requires": {
                 "camelcase": "^5.0.0",
@@ -18157,9 +17753,9 @@
           }
         },
         "secret-stack": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/secret-stack/-/secret-stack-6.1.2.tgz",
-          "integrity": "sha512-J8JlISJnWsEapR5GOOtnFD1JuJ9QHinWzSSzPMIqoVwhz05bnwCmTQvtMRKD5Hk9WrjCrPTprubJvrrYhqHpeg==",
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/secret-stack/-/secret-stack-6.2.1.tgz",
+          "integrity": "sha512-7hw13S77Et4yC23uVXOFDRyullxAvFuoN3XW6PvHlAVkYMirLkyeglPOwPTk5JhYwIKPdpIz6vQ7DM0zSlOUHA==",
           "requires": {
             "debug": "^4.1.0",
             "hoox": "0.0.1",
@@ -20475,9 +20071,9 @@
       }
     },
     "type": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.0.1.tgz",
-      "integrity": "sha512-MAM5dBMJCJNKs9E7JXo4CXRAansRfG0nlJxW7Wf6GZzSOvH31zClSaHdIMWLehe/EGMBkqeC55rrkaOr5Oo7Nw=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.0.3.tgz",
+      "integrity": "sha512-51IMtNfVcee8+9GJvj0spSuFcZHe9vSib6Xtgsny1Km9ugyz2mbS08I3rsUIRYgJohFRFU1160sgRodYz378Hg=="
     },
     "type-check": {
       "version": "0.3.2",
@@ -20772,6 +20368,11 @@
         "static-module": "^3.0.0"
       },
       "dependencies": {
+        "mime": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "ssb-friends": "^4.1.4",
     "ssb-identities": "^2.1.0",
     "ssb-invite": "~2.0.4",
+    "ssb-lan": "^0.1.1",
     "ssb-legacy-conn": "^1.0.25",
     "ssb-local": "^1.0.0",
     "ssb-logging": "^1.0.0",


### PR DESCRIPTION
This uses ssb-lan. 

I noticed that ssb-ahoy also includes ssb-local in ./lib/build-plugins.js, so that probably also needs updating?

Tested IRL with @Powersource and @cblgh