### PR TITLE
Adding support for ia32 and arm64.

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,12 @@
     "appId": "org.ssbc.patchbay",
     "linux": {
       "category": "Network",
-      "target": "AppImage"
+      "target": "AppImage",
+      "arch": [
+        "x64",
+        "ia32",
+        "arm64"
+      ]
     },
     "appImage": {
       "artifactName": "${name}-Linux-${version}-${arch}.${ext}"
@@ -165,11 +170,26 @@
       "icon": "build/dmg-icon.icns"
     },
     "win": {
-      "publisherName": "Secure Scuttlebutt Consortium"
-    },
-    "nsis": {
-      "artifactName": "${name}-Windows-${version}.${ext}",
-      "installerIcon": "build/setup-icon.ico"
+      "publisherName": "Secure Scuttlebutt Consortium",
+      "target": [
+        {
+          "target": "nsis",
+          "artifactName": "${name}-Windows-${version}.${ext}",
+          "installerIcon": "build/setup-icon.ico",
+          "arch": [
+            "x64",
+            "ia32"
+          ]
+        },
+        {
+          "target": "zip",
+          "arch": [
+            "x64",
+            "ia32",
+            "arm64"
+          ]
+        }
+      ]
     }
   },
   "collective": {

--- a/package.json
+++ b/package.json
@@ -155,11 +155,15 @@
     "appId": "org.ssbc.patchbay",
     "linux": {
       "category": "Network",
-      "target": "AppImage",
-      "arch": [
-        "x64",
-        "ia32",
-        "arm64"
+      "target": [
+        {
+          "target": "AppImage",
+          "arch": [
+            "x64",
+            "ia32",
+            "arm64"
+          ]
+        }
       ]
     },
     "appImage": {
@@ -183,6 +187,7 @@
         },
         {
           "target": "zip",
+          "artifactName": "${name}-Windows-${version}.${ext}",
           "arch": [
             "x64",
             "ia32",

--- a/package.json
+++ b/package.json
@@ -184,15 +184,6 @@
             "x64",
             "ia32"
           ]
-        },
-        {
-          "target": "zip",
-          "artifactName": "${name}-Windows-${version}.${ext}",
-          "arch": [
-            "x64",
-            "ia32",
-            "arm64"
-          ]
         }
       ]
     }

--- a/package.json
+++ b/package.json
@@ -160,7 +160,6 @@
           "target": "AppImage",
           "arch": [
             "x64",
-            "ia32",
             "arm64"
           ]
         }


### PR DESCRIPTION
New architectures: ia32 and arm64 enabled for both Linux and Windows.

New windows build target: zip (plays well with package managers.)